### PR TITLE
Document sandbox messaging and add parent bridge

### DIFF
--- a/packages/oai/parent/README.md
+++ b/packages/oai/parent/README.md
@@ -1,0 +1,8 @@
+# Parent host helpers
+
+The React component in this directory implements the outermost side of the
+sandbox protocol. It mounts an iframe that loads the sandbox bundle and
+completes the MessageChannel handshake documented in
+`../reversed/message-protocol.md`. The component exposes strongly typed props
+for tool input/output, widget metadata, and host callbacks so product surfaces
+can integrate without reimplementing the transport glue.

--- a/packages/oai/parent/SandboxParentBridge.tsx
+++ b/packages/oai/parent/SandboxParentBridge.tsx
@@ -1,0 +1,454 @@
+import React, {
+  CSSProperties,
+  MutableRefObject,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import {
+  createGeneratorRpcEndpoint,
+  createRpcEndpoint,
+} from "../reversed/rpc";
+import type {
+  InstrumentPayload,
+  EnvironmentErrorPayload,
+  SecurityViolation,
+  HostApi,
+} from "../reversed/hostMessaging";
+import type { RunWidgetCodeOptions } from "../reversed/runWidgetCode";
+import type { HtmlRunEvent } from "../reversed/runHtml";
+import type { CspConfiguration } from "../reversed/applyCsp";
+import type { SafeAreaDescriptor } from "../reversed/safeArea";
+import type { ThemeName } from "../reversed/theme";
+import {
+  HostRpcMethodName,
+  SANDBOX_GENERATOR_METHODS,
+  SandboxInitMessage,
+  SandboxRpcMethodName,
+} from "../reversed/messageProtocol";
+
+type RpcFunction<Arguments extends unknown[], Result> = ((
+  ...args: Arguments
+) => Promise<Result>) & {
+  withOptions?: (options: { signal?: AbortSignal }) => (
+    ...args: Arguments
+  ) => Promise<Result>;
+};
+
+type GeneratorRpcFunction<Arguments extends unknown[], Yield, Return, Next> = ((
+  ...args: Arguments
+) => AsyncGenerator<Yield, Return, Next>) & {
+  withOptions?: (options: { signal?: AbortSignal }) => (
+    ...args: Arguments
+  ) => AsyncGenerator<Yield, Return, Next>;
+};
+
+export interface SandboxRemoteApi {
+  runWidgetCode?: GeneratorRpcFunction<[RunWidgetCodeOptions], HtmlRunEvent, unknown, void>;
+  setWidgetProps?: RpcFunction<
+    [
+      {
+        widgetId: string;
+        widgetState: unknown;
+        toolInput?: unknown;
+        toolOutput?: unknown;
+        toolResponseMetadata?: unknown;
+      },
+    ],
+    void
+  >;
+  setTheme?: RpcFunction<[{ theme: ThemeName | null }], void>;
+  setSafeArea?: RpcFunction<[{ safeArea: SafeAreaDescriptor | null }], void>;
+  navigate?: RpcFunction<[{ delta?: number; popToRoot?: true }], void>;
+  stop?: RpcFunction<[], void>;
+  getCurrentPath?: RpcFunction<[], string | null>;
+  [key: string]: unknown;
+}
+
+export interface SandboxParentBridgeProps {
+  sandboxUrl: string;
+  sessionId: string;
+  appName: string;
+  locale?: string;
+  html: string;
+  widgetId: string;
+  widgetState: unknown;
+  widgetProps?: unknown;
+  toolInput?: unknown;
+  toolOutput?: unknown;
+  toolResponseMetadata?: unknown;
+  displayMode?: string | null;
+  theme?: ThemeName;
+  safeArea?: SafeAreaDescriptor;
+  maxHeight?: number | null;
+  userAgent?: string | null;
+  csp?: CspConfiguration | null;
+  autoRun?: boolean;
+  className?: string;
+  style?: CSSProperties;
+  iframeRef?: MutableRefObject<HTMLIFrameElement | null>;
+  onEvent?: (event: HtmlRunEvent) => void;
+  onReady?: (api: SandboxRemoteApi) => void;
+  onInstrument?: (payload: InstrumentPayload) => void;
+  onEnvironmentError?: (payload: EnvironmentErrorPayload) => void;
+  onSecurityViolation?: (violation: SecurityViolation) => void;
+  onIntrinsicHeight?: (height: number) => void;
+  onBackgroundColor?: (color: string) => void;
+  onEscapeKey?: () => void;
+  onOpenExternal?: HostApi["openExternal"];
+  onDownloadAsset?: HostApi["getDownloadURL"];
+  onUpdateWidgetState?: HostApi["updateWidgetState"];
+  requestDisplayMode?: HostApi["requestDisplayMode"];
+  callCompletion?: HostApi["callCompletion"];
+  streamCompletion?: (
+    payload: unknown,
+    context: { signal: AbortSignal },
+  ) => AsyncGenerator<unknown, unknown, unknown>;
+  sendFollowUpMessage?: HostApi["sendFollowUpMessage"];
+}
+
+interface HostCallbackRegistry {
+  onInstrument?: (payload: InstrumentPayload) => void;
+  onEnvironmentError?: (payload: EnvironmentErrorPayload) => void;
+  onSecurityViolation?: (violation: SecurityViolation) => void;
+  onIntrinsicHeight?: (height: number) => void;
+  onBackgroundColor?: (color: string) => void;
+  onEscapeKey?: () => void;
+  onOpenExternal?: HostApi["openExternal"];
+  onDownloadAsset?: HostApi["getDownloadURL"];
+  onUpdateWidgetState?: HostApi["updateWidgetState"];
+  requestDisplayMode?: HostApi["requestDisplayMode"];
+  callCompletion?: HostApi["callCompletion"];
+  streamCompletion?: (
+    payload: unknown,
+    context: { signal: AbortSignal },
+  ) => AsyncGenerator<unknown, unknown, unknown>;
+  sendFollowUpMessage?: HostApi["sendFollowUpMessage"];
+}
+
+const EMPTY_GENERATOR = async function* emptyGenerator(): AsyncGenerator<unknown, void, unknown> {};
+
+function buildIframeSrc(baseUrl: string, query: Record<string, string>): string {
+  const url = new URL(baseUrl, typeof window !== "undefined" ? window.location.href : "http://localhost");
+  for (const [key, value] of Object.entries(query)) {
+    if (value.length > 0) {
+      url.searchParams.set(key, value);
+    }
+  }
+  return url.toString();
+}
+
+function toRunOptions(props: SandboxParentBridgeProps): RunWidgetCodeOptions {
+  return {
+    html: props.html,
+    widgetId: props.widgetId,
+    widgetState: props.widgetState,
+    widgetProps: props.widgetProps,
+    toolInput: props.toolInput,
+    toolOutput: props.toolOutput,
+    toolResponseMetadata: props.toolResponseMetadata,
+    displayMode: props.displayMode ?? null,
+    theme: props.theme,
+    userAgent: props.userAgent ?? null,
+    safeArea: props.safeArea,
+    maxHeight: props.maxHeight ?? null,
+    csp: props.csp ?? null,
+  };
+}
+
+export const SandboxParentBridge: React.FC<SandboxParentBridgeProps> = (
+  props,
+) => {
+  const [remoteApi, setRemoteApi] = useState<SandboxRemoteApi | null>(null);
+  const iframeElementRef = props.iframeRef ?? useRef<HTMLIFrameElement | null>(null);
+  const callbacksRef = useRef<HostCallbackRegistry>({});
+  const handshakeCompleteRef = useRef(false);
+  const onReadyRef = useRef(props.onReady);
+
+  useEffect(() => {
+    callbacksRef.current = {
+      onInstrument: props.onInstrument,
+      onEnvironmentError: props.onEnvironmentError,
+      onSecurityViolation: props.onSecurityViolation,
+      onIntrinsicHeight: props.onIntrinsicHeight,
+      onBackgroundColor: props.onBackgroundColor,
+      onEscapeKey: props.onEscapeKey,
+      onOpenExternal: props.onOpenExternal,
+      onDownloadAsset: props.onDownloadAsset,
+      onUpdateWidgetState: props.onUpdateWidgetState,
+      requestDisplayMode: props.requestDisplayMode,
+      callCompletion: props.callCompletion,
+      streamCompletion: props.streamCompletion,
+      sendFollowUpMessage: props.sendFollowUpMessage,
+    };
+  }, [
+    props.onInstrument,
+    props.onEnvironmentError,
+    props.onSecurityViolation,
+    props.onIntrinsicHeight,
+    props.onBackgroundColor,
+    props.onEscapeKey,
+    props.onOpenExternal,
+    props.onDownloadAsset,
+    props.onUpdateWidgetState,
+    props.requestDisplayMode,
+    props.callCompletion,
+    props.streamCompletion,
+    props.sendFollowUpMessage,
+  ]);
+
+  useEffect(() => {
+    onReadyRef.current = props.onReady;
+  }, [props.onReady]);
+
+  const src = useMemo(
+    () =>
+      buildIframeSrc(props.sandboxUrl, {
+        sessionId: props.sessionId,
+        app: props.appName,
+        locale: props.locale ?? "",
+      }),
+    [props.sandboxUrl, props.sessionId, props.appName, props.locale],
+  );
+
+  useEffect(() => {
+    handshakeCompleteRef.current = false;
+    setRemoteApi(null);
+  }, [src]);
+
+  useEffect(() => {
+    const iframe = iframeElementRef.current;
+    if (!iframe) return;
+
+    const handleMessage = (event: MessageEvent) => {
+      if (handshakeCompleteRef.current) return;
+      if (event.source !== iframe.contentWindow) return;
+      const data = event.data as SandboxInitMessage | undefined;
+      if (!data || data.type !== "init") return;
+
+      handshakeCompleteRef.current = true;
+
+      const entries = Object.entries(data.ports ?? {});
+      const sandboxRemote: SandboxRemoteApi = {};
+
+      for (const [name, port] of entries) {
+        if (!(port instanceof MessagePort)) continue;
+        if (SANDBOX_GENERATOR_METHODS.has(name as SandboxRpcMethodName)) {
+          sandboxRemote[name] = createGeneratorRpcEndpoint(port);
+        } else {
+          sandboxRemote[name] = createRpcEndpoint(port);
+        }
+      }
+
+      const hostDescriptor: Record<string, MessagePort> = {};
+      const transfer: MessagePort[] = [];
+      const registerRequest = (
+        name: HostRpcMethodName,
+        handler?: (...args: unknown[]) => unknown | Promise<unknown>,
+      ) => {
+        if (!handler) return;
+        const channel = new MessageChannel();
+        createRpcEndpoint(channel.port1, handler as (...args: unknown[]) => unknown);
+        hostDescriptor[name] = channel.port2;
+        transfer.push(channel.port2);
+      };
+
+      const registerGenerator = (
+        name: HostRpcMethodName,
+        factory?: (
+          payload: unknown,
+          context: { signal: AbortSignal },
+        ) => AsyncGenerator<unknown, unknown, unknown>,
+      ) => {
+        if (!factory) return;
+        const channel = new MessageChannel();
+        createGeneratorRpcEndpoint(channel.port1, (payload: unknown) => {
+          const controller = new AbortController();
+          const iterator = factory(payload, { signal: controller.signal }) ?? EMPTY_GENERATOR();
+          const wrapped = (async function* wrappedGenerator() {
+            for await (const chunk of iterator) {
+              yield chunk;
+            }
+          })();
+          const asyncDispose = Symbol.asyncDispose ?? Symbol.for("Symbol.asyncDispose");
+          const syncDispose = Symbol.dispose ?? Symbol.for("Symbol.dispose");
+          (wrapped as Record<PropertyKey, unknown>)[asyncDispose] = async () => {
+            controller.abort();
+            if (typeof (iterator as { return?: () => Promise<unknown> }).return === "function") {
+              await (iterator as { return?: () => Promise<unknown> }).return?.();
+            }
+          };
+          (wrapped as Record<PropertyKey, unknown>)[syncDispose] = () => {
+            controller.abort();
+            (iterator as { return?: () => unknown }).return?.();
+          };
+          return wrapped;
+        });
+        hostDescriptor[name] = channel.port2;
+        transfer.push(channel.port2);
+      };
+
+      const callbacks = callbacksRef.current;
+
+      registerRequest("sendInstrument", (payload: unknown) => {
+        callbacks.onInstrument?.(payload as InstrumentPayload);
+      });
+      registerRequest("notifyEnvironmentError", (payload: unknown) => {
+        callbacks.onEnvironmentError?.(payload as EnvironmentErrorPayload);
+      });
+      registerRequest("notifySecurityPolicyViolation", (payload: unknown) => {
+        callbacks.onSecurityViolation?.(payload as SecurityViolation);
+      });
+      registerRequest("notifyIntrinsicHeight", (height: unknown) => {
+        if (typeof height === "number") {
+          callbacks.onIntrinsicHeight?.(height);
+        }
+      });
+      registerRequest("notifyBackgroundColor", (color: unknown) => {
+        if (typeof color === "string") {
+          callbacks.onBackgroundColor?.(color);
+        }
+      });
+      registerRequest("notifyEscapeKey", () => {
+        callbacks.onEscapeKey?.();
+      });
+      registerRequest("openExternal", (options: unknown) => {
+        callbacks.onOpenExternal?.(options as { href: string });
+      });
+      registerRequest("getDownloadURL", (assetId: unknown) => {
+        return callbacks.onDownloadAsset?.(assetId as string);
+      });
+      registerRequest("updateWidgetState", (widgetId: unknown, value: unknown) => {
+        callbacks.onUpdateWidgetState?.(widgetId as string, value);
+      });
+      registerRequest("requestDisplayMode", (mode: unknown) => {
+        return callbacks.requestDisplayMode?.(mode);
+      });
+      registerRequest("callCompletion", (payload: unknown) => {
+        return callbacks.callCompletion?.(payload);
+      });
+      registerGenerator("streamCompletion", callbacks.streamCompletion);
+      registerRequest("sendFollowUpMessage", (payload: unknown) => {
+        return callbacks.sendFollowUpMessage?.(payload);
+      });
+
+      data.replyPort.start?.();
+      data.replyPort.postMessage(hostDescriptor, transfer);
+      setRemoteApi(sandboxRemote);
+      onReadyRef.current?.(sandboxRemote);
+    };
+
+    window.addEventListener("message", handleMessage);
+    return () => {
+      window.removeEventListener("message", handleMessage);
+    };
+  }, [iframeElementRef, src]);
+
+  useEffect(() => {
+    if (!remoteApi?.setTheme || props.theme === undefined) return;
+    remoteApi.setTheme({ theme: props.theme ?? null }).catch(() => {});
+  }, [remoteApi, props.theme]);
+
+  useEffect(() => {
+    if (!remoteApi?.setSafeArea || props.safeArea === undefined) return;
+    remoteApi.setSafeArea({ safeArea: props.safeArea ?? null }).catch(() => {});
+  }, [remoteApi, props.safeArea]);
+
+  useEffect(() => {
+    if (!remoteApi?.setWidgetProps) return;
+    remoteApi
+      .setWidgetProps({
+        widgetId: props.widgetId,
+        widgetState: props.widgetState,
+        toolInput: props.toolInput,
+        toolOutput: props.toolOutput,
+        toolResponseMetadata: props.toolResponseMetadata,
+      })
+      .catch(() => {});
+  }, [
+    remoteApi,
+    props.widgetId,
+    props.widgetState,
+    props.toolInput,
+    props.toolOutput,
+    props.toolResponseMetadata,
+  ]);
+
+  useEffect(() => {
+    if (!remoteApi?.runWidgetCode || props.autoRun === false) {
+      return;
+    }
+    const runOptions = toRunOptions(props);
+    let cancelled = false;
+    const abortController = new AbortController();
+    const call = "withOptions" in remoteApi.runWidgetCode
+      ? remoteApi.runWidgetCode.withOptions({ signal: abortController.signal })
+      : remoteApi.runWidgetCode;
+
+    let iterator: AsyncGenerator<HtmlRunEvent> | null = null;
+
+    (async () => {
+      try {
+        iterator = await call(runOptions);
+        for await (const event of iterator) {
+          if (cancelled) break;
+          props.onEvent?.(event);
+        }
+      } catch (error) {
+        if (cancelled) return;
+        const callbacks = callbacksRef.current;
+        if (!callbacks.onEnvironmentError) return;
+        if (error instanceof Error) {
+          callbacks.onEnvironmentError({
+            name: error.name,
+            message: error.message,
+            stack: error.stack ?? null,
+          });
+        } else {
+          callbacks.onEnvironmentError({
+            name: "Error",
+            message: String(error),
+            stack: null,
+          });
+        }
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      abortController.abort();
+      iterator?.return?.(undefined).catch(() => {});
+    };
+  }, [
+    remoteApi,
+    props.autoRun,
+    props.html,
+    props.widgetId,
+    props.widgetState,
+    props.widgetProps,
+    props.toolInput,
+    props.toolOutput,
+    props.toolResponseMetadata,
+    props.displayMode,
+    props.theme,
+    props.userAgent,
+    props.safeArea,
+    props.maxHeight,
+    props.csp,
+    props.onEvent,
+  ]);
+
+  return (
+    <iframe
+      ref={iframeElementRef}
+      src={src}
+      title="sandbox"
+      className={props.className}
+      style={props.style}
+      allow="cross-origin-isolated"
+    />
+  );
+};
+
+export default SandboxParentBridge;

--- a/packages/oai/parent/index.ts
+++ b/packages/oai/parent/index.ts
@@ -1,0 +1,1 @@
+export * from "./SandboxParentBridge";

--- a/packages/oai/reversed/README.md
+++ b/packages/oai/reversed/README.md
@@ -1,0 +1,24 @@
+# Reverse engineered sandbox utilities
+
+This directory collects reimplementations of the smaller helper modules that
+ship in `packages/oai/minified`. Every file has been rewritten with descriptive
+names and inline documentation so that future work on the larger `main` bundle
+can build on clear building blocks.
+
+| Original file | Replacement | Notes |
+| ------------- | ----------- | ----- |
+| `types-Bm40F6nV.js` | `types.ts` | Restores enums for message categories and the custom events used to publish global variables to the iframe window. |
+| `create-async-iterator-ggfG9U7o.js` | `createAsyncIterator.ts` | Reconstructs the push-to-async-iterator adapter. |
+| `apply-csp-oMEag3sR.js` | `applyCsp.ts` | Documents the CSP normalization pipeline and the strictness comparison logic that prevents regressions. |
+| `set-additional-globals-CXY3m52s.js` | `additionalGlobals.ts` | Provides a typed interface for writing sandbox globals and dispatching the companion events. |
+| `set-safe-area-vars-Bn-pRjCL.js` | `safeArea.ts` | Applies CSS variables mirroring the runtime helper. |
+| `set-theme-Cu8raYyE.js` | `theme.ts` | Updates the sandbox document element to match the desired theme. |
+| `navigation-BRdOV7LN.js` | `navigation.ts` | Rebuilds the history instrumentation layer that reports navigation capabilities back to the host. |
+| `run-html-Do8mTV6K.js` | `runHtml.ts` | Restores the inner-iframe lifecycle including console forwarding, CSP violation reporting, height/background heuristics, and host RPC integration. |
+| `run-widget-code-BQGNBqus.js` | `runWidgetCode.ts` | Wraps HTML execution with widget-specific globals, CSP enforcement, and host state wiring. |
+| `main-xonCUAoo.js` (messaging section) | `hostMessaging.ts`, `rpc.ts`, `sandboxFrame.ts`, `sandboxLogger.ts`, `lruCache.ts` | Documents the postMessage RPC protocol, host bridge bootstrap, iframe helpers, and shared utilities used by the sandbox runtime. |
+
+The rewritten modules avoid build-tool artefacts (e.g. synthetic generator
+wrappers) and make the implicit contracts explicit via TypeScript interfaces.
+Each source file includes contextual comments outlining the subsystem that the
+minified helper originally served.

--- a/packages/oai/reversed/additionalGlobals.ts
+++ b/packages/oai/reversed/additionalGlobals.ts
@@ -1,0 +1,74 @@
+import { OpenAIGlobalsEvent, WebPlusGlobalsEvent, SandboxGlobalMap } from "./types";
+
+/**
+ * Minified identifier map from `set-additional-globals-CXY3m52s.js`:
+ *   - `r` → `setAdditionalGlobals`
+ *   - `n` → `iframe`
+ *   - `e` → `additionalGlobals`
+ *   - `s` → `sandboxLogger`
+ *   - `W` → `overwriteExisting`
+ *   - `u` → `dispatchGlobalEvents`
+ */
+
+interface SandboxWindow extends Window {
+  oai?: SandboxGlobalMap;
+  openai?: SandboxGlobalMap;
+  webplus?: SandboxGlobalMap;
+}
+
+export interface SandboxLoggerLike {
+  environmentError(error: unknown): void;
+}
+
+export interface AdditionalGlobalsOptions {
+  iframe: HTMLIFrameElement | null | undefined;
+  additionalGlobals: SandboxGlobalMap;
+  sandboxLogger: SandboxLoggerLike;
+  /**
+   * When true the namespaces are replaced entirely instead of being merged.
+   * This mirrors the `isInit` flag from the original minified implementation.
+   */
+  overwriteExisting?: boolean;
+  replaceExisting?: boolean;
+}
+
+export function setAdditionalGlobals({
+  iframe,
+  additionalGlobals,
+  sandboxLogger,
+  overwriteExisting,
+  replaceExisting,
+}: AdditionalGlobalsOptions): void {
+  const contentWindow = iframe?.contentWindow as SandboxWindow | null | undefined;
+  if (!contentWindow) return;
+
+  const shouldReplace = overwriteExisting ?? replaceExisting ?? false;
+
+  if (shouldReplace) {
+    contentWindow.oai = additionalGlobals;
+    contentWindow.openai = additionalGlobals;
+    contentWindow.webplus = additionalGlobals;
+    return;
+  }
+
+  contentWindow.oai ??= {};
+  contentWindow.openai ??= {};
+  contentWindow.webplus ??= {};
+
+  for (const [name, value] of Object.entries(additionalGlobals)) {
+    try {
+      contentWindow.oai![name] = value;
+      contentWindow.openai![name] = value;
+      contentWindow.webplus![name] = value;
+    } catch (error) {
+      sandboxLogger.environmentError(error);
+    }
+  }
+
+  dispatchGlobalEvents(contentWindow, additionalGlobals);
+}
+
+function dispatchGlobalEvents(target: SandboxWindow, globals: SandboxGlobalMap): void {
+  target.dispatchEvent(new OpenAIGlobalsEvent(globals));
+  target.dispatchEvent(new WebPlusGlobalsEvent(globals));
+}

--- a/packages/oai/reversed/applyCsp.ts
+++ b/packages/oai/reversed/applyCsp.ts
@@ -1,0 +1,258 @@
+/**
+ * Reimplementation of the logic from `apply-csp-oMEag3sR.js`.
+ *
+ * The sandbox injects a Content Security Policy meta tag to control which
+ * origins are available to user code. The minified bundle keeps a small
+ * whitelist of first-party CDNs and merges it with user supplied
+ * configuration. The reimplementation below restores descriptive names and
+ * documents the comparison rules that prevent loosening the policy.
+ *
+ * Minified identifier map:
+ *   - `f` → `DEFAULT_THIRD_PARTY_DOMAINS`
+ *   - `C` → `ALLOWED_PROTOCOLS`
+ *   - `m` → `normalizeDomainList`
+ *   - `p` → `coerceToSpaceSeparatedList`
+ *   - `L` → `buildMetaTagContents`
+ *   - `d` → `previousConfiguration`
+ *   - `i` → `currentMetaTag`
+ *   - `S` → `normalizeDirectiveTokens`
+ *   - `h` → `compareTokenSets`
+ *   - `$` → `comparePolicies`
+ *   - `q` → `createMetaElement`
+ *   - `v` → `applyContentSecurityPolicy`
+ */
+
+const DEFAULT_THIRD_PARTY_DOMAINS = [
+  "cdn.tailwindcss.com",
+  "cdn.jsdelivr.net",
+  "unpkg.com",
+  "*.oaiusercontent.com",
+  "threejs.org",
+];
+
+const ALLOWED_PROTOCOLS = new Set(["https:", "http:", "wss:"]);
+
+export interface CspConfiguration {
+  resourceDomains?: string[] | null;
+  connectDomains?: string[] | null;
+  /**
+   * Trusted environments can provide fully qualified directive values
+   * (including schemes other than HTTP/S and WS). When false we downgrade each
+   * entry to its origin to avoid schema or credential leakage.
+   */
+  isTrusted?: boolean;
+}
+
+interface NormalizedCspConfiguration {
+  resourceDomains: string[];
+  connectDomains: string[];
+  isTrusted: boolean;
+}
+
+type Strictness = "more" | "less" | "equal";
+
+const TOKEN_PATTERN = /^[^\s;,'\"]+$/;
+
+function ensureAbsoluteUrl(candidate: string): URL | null {
+  try {
+    return new URL(candidate);
+  } catch {
+    return null;
+  }
+}
+
+function normalizeDomainList(
+  domains: Iterable<string | null | undefined>,
+  allowArbitraryTokens: boolean,
+): string[] {
+  const result = new Set<string>();
+
+  for (const rawValue of domains) {
+    if (!rawValue) continue;
+
+    let trimmed = rawValue.trim();
+    if (!trimmed) continue;
+
+    if (!/^(?:https?|wss?):/i.test(trimmed)) {
+      trimmed = `https://${trimmed}`;
+    }
+
+    const url = ensureAbsoluteUrl(trimmed);
+    if (!allowArbitraryTokens) {
+      if (!url || !ALLOWED_PROTOCOLS.has(url.protocol)) {
+        continue;
+      }
+    }
+
+    if (url && (url.username || url.password)) {
+      continue;
+    }
+
+    const token = allowArbitraryTokens ? trimmed : url?.origin;
+    if (!token) continue;
+    if (!TOKEN_PATTERN.test(token)) continue;
+
+    result.add(token);
+  }
+
+  return Array.from(result.values());
+}
+
+function coerceToSpaceSeparatedList(values: string[]): string {
+  return values
+    .filter(Boolean)
+    .map((value) => (value.startsWith("http") ? value : `https://${value}`))
+    .join(" ");
+}
+
+function buildMetaTagContents(config: NormalizedCspConfiguration): string {
+  const resourceList = coerceToSpaceSeparatedList([
+    ...DEFAULT_THIRD_PARTY_DOMAINS,
+    ...normalizeDomainList(config.resourceDomains, config.isTrusted),
+  ]);
+
+  const connectList = coerceToSpaceSeparatedList([
+    ...DEFAULT_THIRD_PARTY_DOMAINS,
+    ...normalizeDomainList(config.connectDomains, config.isTrusted),
+  ]);
+
+  const directives = [
+    "default-src 'self'",
+    `script-src 'self' 'wasm-unsafe-eval' 'unsafe-inline' 'unsafe-eval' blob: ${resourceList}`,
+    "worker-src 'self' blob:",
+    `style-src 'self' 'unsafe-inline' ${resourceList}`,
+    `style-src-elem 'self' 'unsafe-inline' ${resourceList}`,
+    "style-src-attr 'unsafe-inline'",
+    `img-src 'self' data: ${resourceList}`,
+    `font-src 'self' ${resourceList}`,
+    `connect-src 'self' ${connectList}`,
+    `media-src 'self' data: ${resourceList}`,
+    "object-src 'none'",
+    "frame-src 'none'",
+    "base-uri 'self'",
+    "upgrade-insecure-requests",
+  ].filter(Boolean);
+
+  return `<meta http-equiv="Content-Security-Policy" content="${directives.join("; ")}">`;
+}
+
+function sanitizeConfiguration(config: CspConfiguration): NormalizedCspConfiguration {
+  return {
+    resourceDomains: config.resourceDomains ?? [],
+    connectDomains: config.connectDomains ?? [],
+    isTrusted: Boolean(config.isTrusted),
+  };
+}
+
+function normalizeDirectiveTokens(values: readonly (string | null | undefined)[]): string[] {
+  if (!values || values.length === 0) return [];
+  if (values.some((value) => value?.trim().toLowerCase() === "'none'")) {
+    return [];
+  }
+
+  if (values.some((value) => value?.trim() === "*")) {
+    return ["*"];
+  }
+
+  const normalized = new Set<string>();
+  for (const token of values) {
+    const trimmed = token?.trim().toLowerCase();
+    if (trimmed) normalized.add(trimmed);
+  }
+  return Array.from(normalized.values());
+}
+
+function compareTokenSets(current: string[], next: string[]): Strictness {
+  const hasWildcard = current.includes("*");
+  const nextHasWildcard = next.includes("*");
+
+  if (hasWildcard && !nextHasWildcard) return "more";
+  if (!hasWildcard && nextHasWildcard) return "less";
+  if (hasWildcard && nextHasWildcard) return "equal";
+
+  const currentSet = new Set(current);
+  const nextSet = new Set(next);
+
+  const nextWithinCurrent = Array.from(nextSet).every((token) => currentSet.has(token));
+  const currentWithinNext = Array.from(currentSet).every((token) => nextSet.has(token));
+
+  if (nextWithinCurrent && currentWithinNext) return "equal";
+  if (nextWithinCurrent && nextSet.size < currentSet.size) return "more";
+  return "less";
+}
+
+function comparePolicies(
+  previous: NormalizedCspConfiguration | null,
+  next: NormalizedCspConfiguration,
+): Strictness {
+  if (!previous) {
+    return "more";
+  }
+
+  let isStricter = false;
+
+  const resourceComparison = compareTokenSets(
+    normalizeDirectiveTokens(previous.resourceDomains),
+    normalizeDirectiveTokens(next.resourceDomains),
+  );
+
+  if (resourceComparison === "less") return "less";
+  if (resourceComparison === "more") isStricter = true;
+
+  const connectComparison = compareTokenSets(
+    normalizeDirectiveTokens(previous.connectDomains),
+    normalizeDirectiveTokens(next.connectDomains),
+  );
+
+  if (connectComparison === "less") return "less";
+  if (connectComparison === "more") isStricter = true;
+
+  return isStricter ? "more" : "equal";
+}
+
+function createMetaElement(metaMarkup: string): HTMLMetaElement {
+  const container = document.createElement("div");
+  container.innerHTML = metaMarkup.trim();
+
+  const meta = container.querySelector('meta[http-equiv="Content-Security-Policy"]');
+  if (!meta) {
+    throw new Error("buildMetaTag() did not produce a CSP <meta> tag");
+  }
+
+  return meta;
+}
+
+let previousConfiguration: NormalizedCspConfiguration | null = null;
+let currentMetaTag: HTMLMetaElement | null = null;
+
+export function applyContentSecurityPolicy(configuration: CspConfiguration | null | undefined): void {
+  if (!configuration) return;
+
+  const normalized = sanitizeConfiguration(configuration);
+  const comparison = comparePolicies(previousConfiguration, normalized);
+
+  if (comparison === "less") {
+    throw new Error("CSP is being loosened");
+  }
+
+  if (comparison === "equal") {
+    return;
+  }
+
+  const markup = buildMetaTagContents(normalized);
+  const metaElement = createMetaElement(markup);
+
+  if (currentMetaTag?.isConnected) {
+    currentMetaTag.replaceWith(metaElement);
+  } else {
+    const existingTag = document.head.querySelector('meta[http-equiv="Content-Security-Policy"]');
+    if (existingTag) {
+      existingTag.replaceWith(metaElement);
+    } else {
+      document.head.appendChild(metaElement);
+    }
+  }
+
+  currentMetaTag = metaElement;
+  previousConfiguration = normalized;
+}

--- a/packages/oai/reversed/createAsyncIterator.ts
+++ b/packages/oai/reversed/createAsyncIterator.ts
@@ -1,0 +1,90 @@
+/**
+ * Restores the semantics of `create-async-iterator-ggfG9U7o.js`.
+ *
+ * The original helper converted push-based callbacks into an async iterator
+ * interface that can be consumed with `for await (...)`. The implementation
+ * below keeps the same control flow without the minified variable names.
+ *
+ * Minified identifier map:
+ *   - `c` → `createAsyncIterator`
+ *   - `s` → `producer`
+ *   - `t` → `isCompleted`
+ *   - `n` → `pendingResolvers`
+ *   - `o` → `queuedResults`
+ *   - `r` → `deliver`
+ *   - `f` → controller `push`
+ *   - `u` → controller `complete`
+ *   - `i` → controller `error`
+ */
+
+export interface AsyncIteratorController<T> {
+  push(value: T): void;
+  complete(): void;
+  error(reason: unknown): void;
+}
+
+export type AsyncIteratorProducer<T> = (controller: AsyncIteratorController<T>) => void;
+
+export function createAsyncIterator<T>(producer: AsyncIteratorProducer<T>): AsyncIterableIterator<T> {
+  let isCompleted = false;
+  const pendingResolvers: Array<(result: IteratorResult<T>) => void> = [];
+  const queuedResults: IteratorResult<T>[] = [];
+
+  const doneResult: IteratorResult<T> = { value: undefined as unknown as T, done: true };
+
+  const deliver = (result: IteratorResult<T>): void => {
+    if (pendingResolvers.length > 0) {
+      const resolve = pendingResolvers.shift()!;
+      resolve(result);
+    } else {
+      queuedResults.push(result);
+    }
+  };
+
+  const controller: AsyncIteratorController<T> = {
+    push(value) {
+      if (isCompleted) return;
+      deliver({ value, done: false });
+    },
+    complete() {
+      if (isCompleted) return;
+      isCompleted = true;
+      while (pendingResolvers.length > 0) {
+        const resolve = pendingResolvers.shift()!;
+        resolve(doneResult);
+      }
+    },
+    error(reason) {
+      if (isCompleted) return;
+      deliver(Promise.reject(reason) as unknown as IteratorResult<T>);
+      controller.complete();
+    },
+  };
+
+  try {
+    producer(controller);
+  } catch (error) {
+    controller.error(error);
+  }
+
+  return {
+    next(): Promise<IteratorResult<T>> {
+      return new Promise((resolve) => {
+        if (queuedResults.length > 0) {
+          resolve(queuedResults.shift()!);
+          return;
+        }
+
+        if (isCompleted) {
+          resolve(doneResult);
+          return;
+        }
+
+        pendingResolvers.push(resolve);
+      });
+    },
+    [Symbol.asyncIterator]() {
+      return this;
+    },
+  };
+}

--- a/packages/oai/reversed/hostMessaging.ts
+++ b/packages/oai/reversed/hostMessaging.ts
@@ -1,0 +1,188 @@
+import { createGeneratorRpcEndpoint, createRpcEndpoint } from "./rpc";
+
+/**
+ * Minified identifier map from `main-xonCUAoo.js`:
+ *   - `Sn` → `initializeHostMessaging`
+ *   - `ie` → `publishHostApi`
+ *   - `L` → `getHostApi`
+ *   - `zn` → `sessionId`
+ *   - `_t` → `appName`
+ *   - `In` → `locale`
+ */
+
+export interface InstrumentPayload {
+  type: "count" | "hist" | "interaction" | "error";
+  label?: string;
+  value?: number;
+  count?: number;
+  tags?: Record<string, string | number>;
+  message?: string;
+  error?: unknown;
+}
+
+export interface SecurityViolation {
+  effectiveDirective: string;
+  violatedDirective: string;
+  blockedURI: string;
+  sourceFile: string | null;
+}
+
+export interface EnvironmentErrorPayload {
+  name: string;
+  message: string;
+  stack: string | null;
+}
+
+export interface HostApi {
+  sendInstrument(payload: InstrumentPayload): void;
+  notifyEnvironmentError(error: EnvironmentErrorPayload): void;
+  notifySecurityPolicyViolation?(violation: SecurityViolation): void;
+  notifyIntrinsicHeight?(height: number): void;
+  notifyBackgroundColor?(cssColor: string): void;
+  notifyEscapeKey?(): void;
+  openExternal?(options: { href: string }): void;
+  getDownloadURL?(assetId: string): Promise<string>;
+  updateWidgetState?(widgetId: string, value: unknown): void;
+  requestDisplayMode?(mode: unknown): Promise<unknown>;
+  callCompletion?(payload: unknown): Promise<unknown>;
+  streamCompletion?(
+    payload: unknown,
+  ): AsyncGenerator<unknown, unknown, unknown> | Promise<AsyncGenerator<unknown, unknown, unknown>>;
+  sendFollowUpMessage?(payload: unknown): Promise<void>;
+  [key: string]: unknown;
+}
+
+type HostHandlers = Record<
+  string,
+  ((...args: unknown[]) => unknown) | ((...args: unknown[]) => AsyncGenerator<unknown, unknown, unknown>) | undefined
+>;
+
+const query = new URLSearchParams(window.location.search);
+
+export const sessionId = query.get("sessionId") ?? "";
+export const locale = query.get("locale") ?? "";
+export const appName = query.get("app") ?? "";
+
+const APP_ORIGINS: Record<string, string> = {
+  chatgpt: "https://chatgpt.com",
+  feather: "https://feather.openai.com",
+  skybridge: "https://skybridge.oaistatic.com",
+};
+
+const userGestureMethods = new Set([
+  "requestDisplayMode",
+  "callCompletion",
+  "streamCompletion",
+  "sendFollowUpMessage",
+  "openExternal",
+]);
+
+let hostApi: HostApi | null = null;
+
+export function publishHostApi(api: HostApi): void {
+  hostApi = api;
+}
+
+export function getHostApi(): HostApi {
+  if (!hostApi) {
+    throw new Error("Host API not published");
+  }
+
+  return new Proxy(hostApi, {
+    get(target, property, receiver) {
+      const value = Reflect.get(target, property, receiver);
+      if (typeof property === "string" && typeof value === "function" && userGestureMethods.has(property)) {
+        return (...args: unknown[]) => {
+          if (!userActivationIsActive()) {
+            console.warn(`Method ${property} requires a synchronous user gesture.`);
+            return undefined;
+          }
+          return (value as (...args: unknown[]) => unknown).apply(target, args);
+        };
+      }
+      if (value == null) {
+        return () => {
+          console.warn(`Host API method ${String(property)} not found`);
+        };
+      }
+      return value;
+    },
+  });
+}
+
+export function userActivationIsActive(): boolean {
+  const activation = navigator.userActivation;
+  return activation ? activation.isActive : true;
+}
+
+function resolveTargetOrigin(): string {
+  return APP_ORIGINS[appName] ?? "*";
+}
+
+async function unregisterServiceWorker(): Promise<boolean> {
+  if (!("serviceWorker" in navigator)) return false;
+  const registration = await navigator.serviceWorker.getRegistration();
+  if (!registration) return false;
+  await registration.unregister();
+  window.location.reload();
+  return true;
+}
+
+function isAsyncGeneratorFunction(value: unknown): value is (...args: unknown[]) => AsyncGenerator {
+  if (typeof value !== "function") return false;
+  return value.constructor?.name === "AsyncGeneratorFunction";
+}
+
+export async function initializeHostMessaging(
+  handlers: HostHandlers,
+  generatorMethods: string[] = [],
+): Promise<HostApi | null> {
+  if (await unregisterServiceWorker()) {
+    return null;
+  }
+
+  const ports = Object.fromEntries(
+    Object.entries(handlers).map(([name, handler]) => {
+      const channel = new MessageChannel();
+      if (handler) {
+        if (isAsyncGeneratorFunction(handler)) {
+          createGeneratorRpcEndpoint(channel.port1, handler as (...args: unknown[]) => AsyncGenerator);
+        } else {
+          createRpcEndpoint(channel.port1, handler as (...args: unknown[]) => unknown);
+        }
+      }
+      return [name, channel.port2];
+    }),
+  );
+
+  const replyChannel = new MessageChannel();
+
+  window.parent.postMessage(
+    {
+      type: "init",
+      ports,
+      replyPort: replyChannel.port2,
+    },
+    resolveTargetOrigin(),
+    [...Object.values(ports), replyChannel.port2],
+  );
+
+  const remoteDescriptor = await new Promise<Record<string, MessagePort>>((resolve) => {
+    replyChannel.port1.onmessage = (event) => resolve(event.data as Record<string, MessagePort>);
+    replyChannel.port1.start();
+  });
+
+  const generatorSet = new Set(generatorMethods);
+
+  const api = Object.fromEntries(
+    Object.entries(remoteDescriptor).map(([name, port]) => {
+      const caller = generatorSet.has(name)
+        ? createGeneratorRpcEndpoint(port)
+        : createRpcEndpoint(port);
+      return [name, caller];
+    }),
+  ) as HostApi;
+
+  publishHostApi(api);
+  return api;
+}

--- a/packages/oai/reversed/lruCache.ts
+++ b/packages/oai/reversed/lruCache.ts
@@ -1,0 +1,51 @@
+/**
+ * Lightweight LRU cache mirroring the behaviour used in `run-html-Do8mTV6K.js`.
+ */
+
+export interface LruCacheOptions {
+  max: number;
+  ttl: number;
+}
+
+interface Entry<V> {
+  value: V;
+  expiresAt: number;
+}
+
+export class LruCache<K, V> {
+  private readonly options: LruCacheOptions;
+  private readonly entries = new Map<K, Entry<V>>();
+
+  constructor(options: LruCacheOptions) {
+    this.options = options;
+  }
+
+  get(key: K): V | undefined {
+    const entry = this.entries.get(key);
+    if (!entry) return undefined;
+
+    if (entry.expiresAt < Date.now()) {
+      this.entries.delete(key);
+      return undefined;
+    }
+
+    // Refresh the entry recency by reinserting it.
+    this.entries.delete(key);
+    this.entries.set(key, entry);
+    return entry.value;
+  }
+
+  set(key: K, value: V): void {
+    const expiresAt = Date.now() + this.options.ttl;
+    this.entries.set(key, { value, expiresAt });
+    this.trim();
+  }
+
+  private trim(): void {
+    while (this.entries.size > this.options.max) {
+      const [oldestKey] = this.entries.keys();
+      if (oldestKey === undefined) break;
+      this.entries.delete(oldestKey);
+    }
+  }
+}

--- a/packages/oai/reversed/message-protocol.md
+++ b/packages/oai/reversed/message-protocol.md
@@ -1,0 +1,100 @@
+# Sandbox messaging protocol
+
+This document captures the semantics of the `window.postMessage` and
+MessageChannel traffic that glues the sandbox iframe to its parent application.
+It ties the reimplemented helpers in this directory back to the original
+`main-xonCUAoo.js` bundle.
+
+## Bootstrap handshake
+
+1. The sandbox dynamically provisions one `MessageChannel` per handler that the
+   parent may call (see the catalogue below). Each `port1` endpoint is bound to
+   either `createRpcEndpoint` or `createGeneratorRpcEndpoint`, while `port2` is
+   prepared for transfer to the parent.【F:packages/oai/reversed/hostMessaging.ts†L115-L156】【F:packages/oai/reversed/rpc.ts†L228-L356】
+2. A second `MessageChannel` carries the reply descriptor. The sandbox posts a
+   single `init` message to `window.parent`, including the handler map and the
+   reply port. All message ports are transferred with the post so ownership is
+   moved to the parent.【F:packages/oai/reversed/hostMessaging.ts†L158-L178】
+3. The parent responds on `replyPort` with a map of host-side RPC entry points.
+   Once received, the sandbox wraps each host function with an RPC caller,
+   respecting the generator list supplied by the parent.【F:packages/oai/reversed/hostMessaging.ts†L180-L200】
+4. The resulting object is published via `getHostApi()` so that every runtime
+   helper (navigation, HTML runner, widget orchestrator, etc.) can reach the
+   host without touching the transport primitives.【F:packages/oai/reversed/hostMessaging.ts†L69-L112】
+
+The `messageProtocol.ts` module enumerates both sides of this bridge so the
+parent UI knows exactly which endpoints to expose and how to decode requests
+coming from the sandbox.【F:packages/oai/reversed/messageProtocol.ts†L1-L210】
+
+## RPC catalogue
+
+### Parent → sandbox
+
+| Method | Kind | Payload | Result | Purpose |
+| ------ | ---- | ------- | ------ | ------- |
+| `runUserCode` | generator | `{ bundle, args? }` | stream of sandbox events | Evaluate arbitrary JS bundles and forward lifecycle updates |
+| `buildUserCode` | request | `{ files, entrypoint }` | build artifact or `null` | Transpile uploaded source before execution |
+| `prepareEnvironment` | request | `{ packages, registryBaseUrl? }` | `void` | Pre-install npm packages inside the sandbox |
+| `runWidgetCode` | generator | `RunWidgetCodeOptions` | stream of `HtmlRunEvent` | Render widgets inside the inner iframe |
+| `validate` | request | `{ code, props }` | `boolean` | Pre-validate SSR output |
+| `stop` | request | `void` | `void` | Tear down the current iframe and instrumentation |
+| `setEditMode` | request | `boolean` | `void` | Toggle inline editing helpers |
+| `screenshot` | request | `void` | `{ imageBase64, scrollX, scrollY }` or `null` | Capture a DOM snapshot |
+| `setAdditionalGlobals` | request | `{ additionalGlobals }` | `void` | Publish ad-hoc globals into the sandbox window |
+| `setWidgetProps` | request | `{ widgetId, widgetState, toolInput?, toolOutput?, toolResponseMetadata? }` | `void` | Refresh widget-specific globals |
+| `setTheme` | request | `{ theme }` | `void` | Apply theming and mirror it to globals |
+| `setSafeArea` | request | `{ safeArea }` | `void` | Update safe-area CSS variables and globals |
+| `navigate` | request | `{ delta? }` or `{ popToRoot: true }` | `void` | Drive the instrumented history API |
+| `getCurrentPath` | request | `void` | `string` or `null` | Report the iframe’s current pathname |
+
+The table mirrors `SANDBOX_RPC_METHODS`; generator invocations stream sandbox
+messages until completion.【F:packages/oai/reversed/messageProtocol.ts†L15-L118】 The `runWidgetCode`
+implementation wires host-provided globals, enforces CSP, and yields HTML events
+as it executes within the nested iframe.【F:packages/oai/reversed/runWidgetCode.ts†L1-L80】【F:packages/oai/reversed/runHtml.ts†L432-L624】
+
+### Sandbox → parent
+
+| Method | Kind | Payload | Result | Purpose |
+| ------ | ---- | ------- | ------ | ------- |
+| `sendInstrument` | request | `InstrumentPayload` | `void` | Forward counters, histograms, and interaction markers |
+| `notifyEnvironmentError` | request | `EnvironmentErrorPayload` | `void` | Escalate fatal runtime errors |
+| `notifySecurityPolicyViolation` | request | `SecurityViolation` | `void` | Surface CSP violations |
+| `notifyIntrinsicHeight` | request | `number` | `void` | Push measured iframe height changes |
+| `notifyBackgroundColor` | request | `string` | `void` | Report the first opaque background color |
+| `notifyEscapeKey` | request | `void` | `void` | Bubble Escape presses to the host |
+| `openExternal` | request | `{ href }` | `void` | Ask the host to open external links |
+| `getDownloadURL` | request | `string` | `string` | Resolve custom download protocols |
+| `updateWidgetState` | request | `{ widgetId, value }` | `void` | Write widget state back to the host store |
+| `requestDisplayMode` | request | `unknown` | `unknown` | Negotiate layout changes that require a user gesture |
+| `callCompletion` | request | `unknown` | `unknown` | Trigger a one-shot completion |
+| `streamCompletion` | generator | `unknown` | stream of tokens | Stream multi-turn completions |
+| `sendFollowUpMessage` | request | `unknown` | `void` | Inject an additional chat turn |
+
+These methods map to `HOST_RPC_METHODS`. User gesture sensitive calls are
+wrapped in a proxy that checks `navigator.userActivation` so widgets cannot call
+these helpers outside a trusted click path.【F:packages/oai/reversed/messageProtocol.ts†L122-L210】【F:packages/oai/reversed/hostMessaging.ts†L89-L112】
+
+## Nested iframe architecture
+
+The sandbox iframe (`packages/oai/reversed` code) never runs untrusted HTML
+within its own document. Instead it provisions an inner iframe on demand via
+`ensureSandboxIframe()`, replaces any previous instance, and tears it down once
+the new content signals readiness.【F:packages/oai/reversed/runHtml.ts†L452-L548】【F:packages/oai/reversed/sandboxFrame.ts†L13-L42】
+
+During each run the sandbox:
+
+- Installs navigation instrumentation on the inner iframe’s `history` object so
+  the host receives `canGoBack`/`canGoForward` updates while still owning the
+  containing UI.【F:packages/oai/reversed/navigation.ts†L25-L196】
+- Injects safe-area CSS variables and theme tokens into the inner document to
+  match the host shell.【F:packages/oai/reversed/runHtml.ts†L514-L542】
+- Forwards console output, runtime errors, and CSP violations back to the host
+  via the RPC helpers described above.【F:packages/oai/reversed/runHtml.ts†L222-L410】
+- Measures background color and intrinsic height so the host can resize the
+  outer iframe without guesswork.【F:packages/oai/reversed/runHtml.ts†L480-L520】
+
+This two-iframe structure isolates ephemeral widget execution from the bridge
+logic. The outer iframe keeps the long-lived message channels and logging state,
+while the inner iframe can be discarded whenever new HTML is written, ensuring a
+clean DOM, deterministic CSP enforcement, and reliable measurement callbacks
+without renegotiating the host connection.【F:packages/oai/reversed/runHtml.ts†L500-L624】【F:packages/oai/reversed/sandboxLogger.ts†L33-L85】

--- a/packages/oai/reversed/messageProtocol.ts
+++ b/packages/oai/reversed/messageProtocol.ts
@@ -1,0 +1,290 @@
+import type { RunWidgetCodeOptions } from "./runWidgetCode";
+import type { HtmlRunEvent } from "./runHtml";
+import type { SafeAreaDescriptor } from "./safeArea";
+import type { ThemeName } from "./theme";
+
+/**
+ * Canonical catalogue of RPC calls exchanged between the sandbox iframe and
+ * its parent host. This mirrors the descriptors embedded in the minified
+ * `main-xonCUAoo.js` bundle while attaching semantically meaningful
+ * descriptions.
+ */
+
+export type SandboxRpcMethodName =
+  | "runUserCode"
+  | "buildUserCode"
+  | "prepareEnvironment"
+  | "runWidgetCode"
+  | "validate"
+  | "stop"
+  | "setEditMode"
+  | "screenshot"
+  | "setAdditionalGlobals"
+  | "setWidgetProps"
+  | "setTheme"
+  | "setSafeArea"
+  | "navigate"
+  | "getCurrentPath";
+
+export interface SandboxRpcDescription {
+  readonly name: SandboxRpcMethodName;
+  readonly invocation: "generator" | "request";
+  readonly summary: string;
+  /**
+   * Human readable contract for the call arguments forwarded by the parent.
+   */
+  readonly request: string;
+  /**
+   * Human readable contract for the resolved value (or streamed payloads in
+   * case of generators) produced by the sandbox.
+   */
+  readonly response: string;
+}
+
+export const SANDBOX_RPC_METHODS: readonly SandboxRpcDescription[] = [
+  {
+    name: "runUserCode",
+    invocation: "generator",
+    summary: "Executes arbitrary user-authored JavaScript inside the sandbox runtime.",
+    request:
+      "{ bundle: Blob | string, args?: unknown } — dynamic import payload emitted by the build step.",
+    response:
+      "Async generator of SandboxMessage events mirroring console output, logs, and lifecycle markers.",
+  },
+  {
+    name: "buildUserCode",
+    invocation: "request",
+    summary: "Runs the on-the-fly bundler to transpile an uploaded script before execution.",
+    request: "{ files: Record<string, string>, entrypoint: string }",
+    response: "Promise resolving to a build artifact descriptor or null when compilation fails.",
+  },
+  {
+    name: "prepareEnvironment",
+    invocation: "request",
+    summary: "Installs npm-style dependencies into the sandbox prior to execution.",
+    request: "{ packages: string[], registryBaseUrl?: string }",
+    response: "Promise<void> signalling completion of the installation phase.",
+  },
+  {
+    name: "runWidgetCode",
+    invocation: "generator",
+    summary: "Streams lifecycle events while rendering a widget's HTML payload inside the inner iframe.",
+    request: "RunWidgetCodeOptions",
+    response: "AsyncGenerator<HtmlRunEvent>",
+  },
+  {
+    name: "validate",
+    invocation: "request",
+    summary: "Validates a React tree for server rendering prior to hydration inside the sandbox.",
+    request: "{ code: string, props: unknown }",
+    response: "Promise<boolean> indicating whether validation passed.",
+  },
+  {
+    name: "stop",
+    invocation: "request",
+    summary: "Destroys the current sandbox iframe and resets instrumentation hooks.",
+    request: "void",
+    response: "Promise<void>",
+  },
+  {
+    name: "setEditMode",
+    invocation: "request",
+    summary: "Enables or disables the inline code editor helpers that wrap the sandbox.",
+    request: "boolean",
+    response: "Promise<void>",
+  },
+  {
+    name: "screenshot",
+    invocation: "request",
+    summary: "Captures a data URL snapshot of the current sandbox DOM.",
+    request: "void",
+    response:
+      "Promise<{ imageBase64: string, scrollX: number, scrollY: number } | null> for further processing.",
+  },
+  {
+    name: "setAdditionalGlobals",
+    invocation: "request",
+    summary: "Injects ad-hoc globals (tool input/output, widget helpers, etc.) into the inner iframe.",
+    request: "{ additionalGlobals: Record<string, unknown> }",
+    response: "Promise<void>",
+  },
+  {
+    name: "setWidgetProps",
+    invocation: "request",
+    summary: "Refreshes widget-scoped globals such as state, props, and follow-up metadata.",
+    request:
+      "{ widgetId: string, widgetState: unknown, toolInput?: unknown, toolOutput?: unknown, toolResponseMetadata?: unknown }",
+    response: "Promise<void>",
+  },
+  {
+    name: "setTheme",
+    invocation: "request",
+    summary: "Applies the current theme token to the inner iframe and republishes it as a global.",
+    request: "{ theme: ThemeName | null }",
+    response: "Promise<void>",
+  },
+  {
+    name: "setSafeArea",
+    invocation: "request",
+    summary: "Updates safe-area padding CSS variables in the inner iframe and mirrors them to globals.",
+    request: "{ safeArea: SafeAreaDescriptor | null }",
+    response: "Promise<void>",
+  },
+  {
+    name: "navigate",
+    invocation: "request",
+    summary: "Invokes history navigation helpers instrumented inside the sandbox iframe.",
+    request: "{ delta?: number } | { popToRoot: true }",
+    response: "Promise<void>",
+  },
+  {
+    name: "getCurrentPath",
+    invocation: "request",
+    summary: "Returns the sandbox iframe's current pathname for analytics or routing integration.",
+    request: "void",
+    response: "Promise<string | null>",
+  },
+] as const;
+
+export const SANDBOX_GENERATOR_METHODS = new Set<SandboxRpcMethodName>(
+  SANDBOX_RPC_METHODS.filter((method) => method.invocation === "generator").map((method) => method.name),
+);
+
+export type HostRpcMethodName =
+  | "sendInstrument"
+  | "notifyEnvironmentError"
+  | "notifySecurityPolicyViolation"
+  | "notifyIntrinsicHeight"
+  | "notifyBackgroundColor"
+  | "notifyEscapeKey"
+  | "openExternal"
+  | "getDownloadURL"
+  | "updateWidgetState"
+  | "requestDisplayMode"
+  | "callCompletion"
+  | "streamCompletion"
+  | "sendFollowUpMessage";
+
+export interface HostRpcDescription {
+  readonly name: HostRpcMethodName;
+  readonly invocation: "generator" | "request";
+  readonly summary: string;
+  readonly request: string;
+  readonly response: string;
+}
+
+export const HOST_RPC_METHODS: readonly HostRpcDescription[] = [
+  {
+    name: "sendInstrument",
+    invocation: "request",
+    summary: "Records telemetry counters, histograms, or interaction markers on the host side.",
+    request: "InstrumentPayload",
+    response: "Promise<void>",
+  },
+  {
+    name: "notifyEnvironmentError",
+    invocation: "request",
+    summary: "Reports a fatal sandbox error to the host UI.",
+    request: "EnvironmentErrorPayload",
+    response: "Promise<void>",
+  },
+  {
+    name: "notifySecurityPolicyViolation",
+    invocation: "request",
+    summary: "Surfaces CSP violations triggered within the sandbox iframe.",
+    request: "SecurityViolation",
+    response: "Promise<void>",
+  },
+  {
+    name: "notifyIntrinsicHeight",
+    invocation: "request",
+    summary: "Sends measured inner iframe height updates so the host can resize the container.",
+    request: "number",
+    response: "Promise<void>",
+  },
+  {
+    name: "notifyBackgroundColor",
+    invocation: "request",
+    summary: "Informs the host about the first opaque background color rendered inside the sandbox.",
+    request: "string",
+    response: "Promise<void>",
+  },
+  {
+    name: "notifyEscapeKey",
+    invocation: "request",
+    summary: "Alerts the host that the sandbox captured an Escape key press.",
+    request: "void",
+    response: "Promise<void>",
+  },
+  {
+    name: "openExternal",
+    invocation: "request",
+    summary: "Requests the host to open an external URL (instead of allowing the sandbox to navigate).",
+    request: "{ href: string }",
+    response: "Promise<void>",
+  },
+  {
+    name: "getDownloadURL",
+    invocation: "request",
+    summary: "Resolves custom asset URLs (e.g. sediment://) to downloadable HTTPS endpoints.",
+    request: "string",
+    response: "Promise<string>",
+  },
+  {
+    name: "updateWidgetState",
+    invocation: "request",
+    summary: "Writes widget state changes back into the host application store.",
+    request: "{ widgetId: string, value: unknown }",
+    response: "Promise<void>",
+  },
+  {
+    name: "requestDisplayMode",
+    invocation: "request",
+    summary: "Asks the host to change how the widget is rendered (e.g. compact vs. expanded).",
+    request: "unknown",
+    response: "Promise<unknown>",
+  },
+  {
+    name: "callCompletion",
+    invocation: "request",
+    summary: "Invokes a single-shot completion on behalf of the widget.",
+    request: "unknown",
+    response: "Promise<unknown>",
+  },
+  {
+    name: "streamCompletion",
+    invocation: "generator",
+    summary: "Streams tokens from a long-running completion request over the RPC bridge.",
+    request: "unknown",
+    response: "AsyncGenerator<unknown>",
+  },
+  {
+    name: "sendFollowUpMessage",
+    invocation: "request",
+    summary: "Pushes a follow-up chat turn back into the host conversation.",
+    request: "unknown",
+    response: "Promise<void>",
+  },
+] as const;
+
+export const HOST_GENERATOR_METHODS = new Set<HostRpcMethodName>(
+  HOST_RPC_METHODS.filter((method) => method.invocation === "generator").map((method) => method.name),
+);
+
+export interface SandboxInitMessage {
+  type: "init";
+  ports: Record<SandboxRpcMethodName | string, MessagePort>;
+  replyPort: MessagePort;
+}
+
+export interface RunWidgetInvocation {
+  options: RunWidgetCodeOptions;
+  iterator: AsyncGenerator<HtmlRunEvent>;
+}
+
+export interface ParentSandboxState {
+  iframe: HTMLIFrameElement | null;
+  lastRun?: RunWidgetInvocation;
+  theme?: ThemeName | null;
+  safeArea?: SafeAreaDescriptor | null;
+}

--- a/packages/oai/reversed/navigation.ts
+++ b/packages/oai/reversed/navigation.ts
@@ -1,0 +1,263 @@
+/**
+ * Reconstructed from `navigation-BRdOV7LN.js`.
+ *
+ * Minified identifier map:
+ *   - `r` → `stack`
+ *   - `s` → `hashes`
+ *   - `o` → `currentIndex`
+ *   - `y` → `counter`
+ *   - `a` → `pendingDelta`
+ *   - `h` → `currentHash()` helper
+ *   - `I` → `extractHash()` helper
+ *   - `g` → `nextId()`
+ *   - `l` → `ensureInitialized()`
+ *   - `p` → `emit()`
+ *   - `b` → `recordPush()`
+ *   - `m` → `recordReplace()`
+ *   - `f` → `applyDelta()`
+ *   - `S` → `handlePopState()`
+ *   - `E` → `handleHashChange()`
+ *   - `k` → `classifyDelta()`
+ */
+
+export type NavigationEventType = "push" | "replace" | "pop" | "update";
+
+export interface NavigationNotification {
+  type: NavigationEventType;
+  canGoBack: boolean;
+  canGoForward: boolean;
+}
+
+export interface NavigationInstrumentationOptions {
+  iframe: HTMLIFrameElement;
+  notify?(change: NavigationNotification): void;
+}
+
+interface InstrumentedHistory extends History {
+  popToRoot?: (this: History) => unknown;
+}
+
+export function installNavigationInstrumentation({
+  iframe,
+  notify,
+}: NavigationInstrumentationOptions): () => void {
+  const iframeWindow = iframe.contentWindow;
+  if (!iframeWindow) {
+    return () => {};
+  }
+
+  const history = iframeWindow.history as InstrumentedHistory;
+  const notifyChange = notify ?? (() => {});
+  const stack: number[] = [];
+  const hashes: string[] = [];
+  let currentIndex = -1;
+  let counter = 0;
+  let pendingDelta: number | null = null;
+
+  const currentHash = (): string => iframeWindow.location.hash ?? "";
+
+  const extractHash = (url: string | null | undefined): string => {
+    if (!url) return "";
+    try {
+      return new URL(url, iframeWindow.location.href).hash ?? "";
+    } catch {
+      return "";
+    }
+  };
+
+  const nextId = (): number => {
+    counter += 1;
+    return counter;
+  };
+
+  const ensureInitialized = (): void => {
+    if (stack.length === 0) {
+      stack.push(nextId());
+      hashes.push(currentHash());
+      currentIndex = 0;
+      return;
+    }
+
+    if (hashes.length === 0) {
+      hashes.push(currentHash());
+    }
+  };
+
+  const emit = (type: NavigationEventType): void => {
+    if (stack.length === 0 || currentIndex < 0) return;
+    notifyChange({
+      type,
+      canGoBack: currentIndex > 0,
+      canGoForward: currentIndex < stack.length - 1,
+    });
+  };
+
+  const recordPush = (type: NavigationEventType, hashValue: string = currentHash()): void => {
+    ensureInitialized();
+    if (currentIndex < stack.length - 1) {
+      stack.splice(currentIndex + 1);
+      hashes.splice(currentIndex + 1);
+    }
+
+    stack.push(nextId());
+    hashes.push(hashValue);
+    currentIndex = stack.length - 1;
+    pendingDelta = null;
+    emit(type);
+  };
+
+  const recordReplace = (hashValue: string = currentHash()): void => {
+    ensureInitialized();
+    if (currentIndex >= 0) {
+      stack[currentIndex] = nextId();
+      hashes[currentIndex] = hashValue;
+    }
+    pendingDelta = null;
+    emit("replace");
+  };
+
+  const classifyDelta = (delta: number): NavigationEventType => {
+    if (delta < 0) return "pop";
+    if (delta > 0) return "push";
+    return "update";
+  };
+
+  const applyDelta = (delta: number): void => {
+    ensureInitialized();
+    const normalized = Number.isFinite(delta) ? Math.trunc(delta) : 0;
+    if (normalized !== 0) {
+      currentIndex = Math.min(stack.length - 1, Math.max(0, currentIndex + normalized));
+    }
+
+    pendingDelta = null;
+    emit(classifyDelta(normalized));
+  };
+
+  const handlePopState = (): void => {
+    applyDelta(pendingDelta ?? -1);
+  };
+
+  const handleHashChange = (event: HashChangeEvent): void => {
+    const current = currentHash();
+
+    if (pendingDelta != null) {
+      applyDelta(pendingDelta);
+      return;
+    }
+
+    ensureInitialized();
+
+    const previousHash = extractHash(event.oldURL);
+    const previousIndex = hashes.lastIndexOf(current);
+
+    if (previousIndex !== -1 && previousIndex !== currentIndex) {
+      applyDelta(previousIndex - currentIndex);
+      return;
+    }
+
+    if (previousIndex === currentIndex) {
+      emit("update");
+      return;
+    }
+
+    if (previousHash && hashes[currentIndex] === previousHash) {
+      recordReplace(current);
+      return;
+    }
+
+    recordPush("push", current);
+  };
+
+  const originalPushState = history.pushState;
+  history.pushState = function pushState(
+    ...args: Parameters<History["pushState"]>
+  ): ReturnType<History["pushState"]> {
+    const result = originalPushState.apply(this, args);
+    recordPush("push");
+    return result;
+  };
+
+  const originalReplaceState = history.replaceState;
+  history.replaceState = function replaceState(
+    ...args: Parameters<History["replaceState"]>
+  ): ReturnType<History["replaceState"]> {
+    const result = originalReplaceState.apply(this, args);
+    recordReplace();
+    return result;
+  };
+
+  const originalBack = history.back;
+  history.back = function back(
+    ...args: Parameters<History["back"]>
+  ): ReturnType<History["back"]> {
+    pendingDelta = -1;
+    return originalBack.apply(this, args);
+  };
+
+  const originalForward = history.forward;
+  history.forward = function forward(
+    ...args: Parameters<History["forward"]>
+  ): ReturnType<History["forward"]> {
+    pendingDelta = 1;
+    return originalForward.apply(this, args);
+  };
+
+  const originalGo = history.go;
+  history.go = function go(
+    ...args: Parameters<History["go"]>
+  ): ReturnType<History["go"]> {
+    const [value = 0] = args;
+    const parsed =
+      typeof value === "number" && Number.isFinite(value)
+        ? Math.trunc(value)
+        : Number.parseInt(String(value), 10);
+    pendingDelta = Number.isFinite(parsed) ? parsed : null;
+    return originalGo.apply(this, args);
+  };
+
+  const originalPopToRoot = history.popToRoot;
+  history.popToRoot = function popToRoot(): ReturnType<History["go"]> | void {
+    ensureInitialized();
+    const delta = -currentIndex;
+    if (delta === 0) {
+      pendingDelta = null;
+      return;
+    }
+    pendingDelta = delta;
+    return originalGo.call(this, delta);
+  };
+
+  iframeWindow.addEventListener("popstate", handlePopState);
+  iframeWindow.addEventListener("hashchange", handleHashChange);
+
+  ensureInitialized();
+  emit("replace");
+
+  return () => {
+    iframeWindow.removeEventListener("popstate", handlePopState);
+    iframeWindow.removeEventListener("hashchange", handleHashChange);
+    history.pushState = originalPushState;
+    history.replaceState = originalReplaceState;
+    history.back = originalBack;
+    history.forward = originalForward;
+    history.go = originalGo;
+    if (originalPopToRoot) {
+      history.popToRoot = originalPopToRoot;
+    } else {
+      delete history.popToRoot;
+    }
+  };
+}
+
+export function go(iframe: HTMLIFrameElement | null | undefined, delta?: number): void {
+  const targetWindow = iframe?.contentWindow;
+  targetWindow?.history.go(delta);
+}
+
+export function popToRoot(iframe: HTMLIFrameElement | null | undefined): void {
+  const targetWindow = iframe?.contentWindow;
+  const history = targetWindow?.history as InstrumentedHistory | undefined;
+  history?.popToRoot?.call(history);
+}
+
+export const navigation = { go, popToRoot };

--- a/packages/oai/reversed/rpc.ts
+++ b/packages/oai/reversed/rpc.ts
@@ -1,0 +1,508 @@
+const CALL_MESSAGE = "CALL" as const;
+const RESOLVE_MESSAGE = "RESOLVE" as const;
+const REJECT_MESSAGE = "REJECT" as const;
+const ABORT_MESSAGE = "ABORT" as const;
+const GENERATOR_MESSAGE = "GENERATOR_GENERATE" as const;
+
+/**
+ * Minified identifier map from `main-xonCUAoo.js`:
+ *   - `D` → `createRpcEndpoint`
+ *   - `xt` → `createGeneratorRpcEndpoint`
+ *   - `Bt`/`bt`/`Dt`/`It` → `CALL_MESSAGE`/`RESOLVE_MESSAGE`/`REJECT_MESSAGE`/`ABORT_MESSAGE`
+ *   - `vt` → `GENERATOR_MESSAGE`
+ */
+
+export interface RpcCallOptions {
+  /** Abort signal forwarded to the remote handler. */
+  signal?: AbortSignal;
+  /** Additional transferable objects to forward alongside the call. */
+  transfer?: Transferable[];
+}
+
+export type RpcHandler<Arguments extends unknown[], Result> = (
+  this: { signal: AbortSignal },
+  ...args: Arguments
+) => Result | Promise<Result>;
+
+export interface RpcCaller<Arguments extends unknown[], Result> {
+  (...args: Arguments): Promise<Result>;
+  withOptions(options: RpcCallOptions): RpcCaller<Arguments, Result>;
+}
+
+type RpcEnvelope =
+  | [typeof CALL_MESSAGE, ...unknown[]]
+  | [typeof RESOLVE_MESSAGE, unknown]
+  | [typeof REJECT_MESSAGE, unknown]
+  | [typeof ABORT_MESSAGE];
+
+function isCallEnvelope(value: RpcEnvelope): value is [typeof CALL_MESSAGE, ...unknown[]] {
+  return Array.isArray(value) && value[0] === CALL_MESSAGE;
+}
+
+function isAbortEnvelope(value: RpcEnvelope): value is [typeof ABORT_MESSAGE] {
+  return Array.isArray(value) && value[0] === ABORT_MESSAGE;
+}
+
+/**
+ * Best-effort structured clone used when `postMessage` raises `DataCloneError`.
+ * Mirrors the `Ot` helper from the minified bundle.
+ */
+function cloneForTransport<T>(value: T, seen: WeakMap<object, unknown> = new WeakMap()): T {
+  const structuredCloneFn: typeof structuredClone | undefined =
+    typeof structuredClone === "function" ? structuredClone : undefined;
+
+  if (structuredCloneFn) {
+    try {
+      // Browsers that support `structuredClone` will bail out early.
+      return structuredCloneFn(value);
+    } catch {
+      // Fall back to manual cloning below.
+    }
+  }
+
+  try {
+    if (value === null) return value;
+    if (typeof value !== "object") {
+      if (typeof value === "symbol" || typeof value === "function" || typeof value === "undefined") {
+        return String(value) as unknown as T;
+      }
+      return value;
+    }
+
+    if (seen.has(value as object)) {
+      return seen.get(value as object) as T;
+    }
+
+    if (value instanceof Date) {
+      return new Date(value.getTime()) as unknown as T;
+    }
+
+    if (value instanceof RegExp) {
+      const clone = new RegExp(value.source, value.flags);
+      clone.lastIndex = value.lastIndex;
+      return clone as unknown as T;
+    }
+
+    if (value instanceof ArrayBuffer) {
+      return value.slice(0) as unknown as T;
+    }
+
+    if (value instanceof DataView) {
+      const buffer = cloneForTransport(value.buffer, seen);
+      try {
+        return new DataView(buffer as ArrayBufferLike, value.byteOffset, value.byteLength) as unknown as T;
+      } catch {
+        return String(value) as unknown as T;
+      }
+    }
+
+    if (ArrayBuffer.isView(value) && !(value instanceof DataView)) {
+      try {
+        if (typeof (value as typeof value & { slice?: () => unknown }).slice === "function") {
+          return (value as typeof value & { slice(): T }).slice();
+        }
+        const TypedArray = (value as { constructor: new (length: number) => typeof value }).constructor;
+        const clone = new TypedArray((value as { length: number }).length);
+        clone.set(value as unknown as ArrayLike<number>);
+        return clone as unknown as T;
+      } catch {
+        return String(value) as unknown as T;
+      }
+    }
+
+    if (value instanceof Map) {
+      const clone = new Map();
+      seen.set(value, clone);
+      for (const [key, entry] of value.entries()) {
+        clone.set(cloneForTransport(key, seen), cloneForTransport(entry, seen));
+      }
+      return clone as unknown as T;
+    }
+
+    if (value instanceof Set) {
+      const clone = new Set();
+      seen.set(value, clone);
+      for (const entry of value.values()) {
+        clone.add(cloneForTransport(entry, seen));
+      }
+      return clone as unknown as T;
+    }
+
+    if (typeof Blob !== "undefined" && value instanceof Blob) {
+      try {
+        if (typeof File !== "undefined" && value instanceof File) {
+          return new File([value], value.name, {
+            type: value.type,
+            lastModified: value.lastModified,
+          }) as unknown as T;
+        }
+        return new Blob([value], { type: value.type }) as unknown as T;
+      } catch {
+        return String(value) as unknown as T;
+      }
+    }
+
+    if (typeof URL !== "undefined" && value instanceof URL) {
+      try {
+        return new URL(value.toString()) as unknown as T;
+      } catch {
+        return String(value) as unknown as T;
+      }
+    }
+
+    if (typeof URLSearchParams !== "undefined" && value instanceof URLSearchParams) {
+      try {
+        return new URLSearchParams(value.toString()) as unknown as T;
+      } catch {
+        return String(value) as unknown as T;
+      }
+    }
+
+    if (value instanceof Error) {
+      const source = value as Error & Record<string, unknown>;
+      let clone: Error;
+      try {
+        const Ctor = (source as { constructor?: new (message?: string) => Error }).constructor;
+        clone = typeof Ctor === "function" ? new Ctor(source.message) : new Error(source.message);
+      } catch {
+        clone = new Error(source.message);
+      }
+      clone.name = source.name;
+      if (typeof source.stack === "string") {
+        clone.stack = source.stack;
+      }
+      if ("cause" in source) {
+        try {
+          (clone as { cause?: unknown }).cause = cloneForTransport(source.cause, seen);
+        } catch {
+          (clone as { cause?: unknown }).cause = String(source.cause);
+        }
+      }
+      for (const key of Object.keys(source)) {
+        try {
+          (clone as Record<string, unknown>)[key] = cloneForTransport(source[key], seen);
+        } catch {
+          (clone as Record<string, unknown>)[key] = String(source[key]);
+        }
+      }
+      return clone as unknown as T;
+    }
+
+    if (typeof SharedArrayBuffer !== "undefined" && value instanceof SharedArrayBuffer) {
+      return String(value) as unknown as T;
+    }
+    if (typeof WeakMap !== "undefined" && value instanceof WeakMap) {
+      return String(value) as unknown as T;
+    }
+    if (typeof WeakSet !== "undefined" && value instanceof WeakSet) {
+      return String(value) as unknown as T;
+    }
+
+    if (Array.isArray(value)) {
+      const clone: unknown[] = new Array(value.length);
+      seen.set(value, clone);
+      for (let index = 0; index < value.length; index += 1) {
+        if (index in value) {
+          clone[index] = cloneForTransport(value[index], seen);
+        }
+      }
+      return clone as unknown as T;
+    }
+
+    const clone: Record<string, unknown> = {};
+    seen.set(value, clone);
+    for (const key of Object.keys(value as Record<string, unknown>)) {
+      let property: unknown;
+      try {
+        property = (value as Record<string, unknown>)[key];
+      } catch (error) {
+        property = String(error);
+      }
+      clone[key] = cloneForTransport(property, seen);
+    }
+    return clone as unknown as T;
+  }
+}
+
+function makeCaller<Arguments extends unknown[], Result>(
+  port: MessagePort,
+  options: RpcCallOptions,
+): RpcCaller<Arguments, Result> {
+  const call: RpcCaller<Arguments, Result> = (...args) =>
+    new Promise<Result>((resolve, reject) => {
+      const { port1, port2 } = new MessageChannel();
+      port1.start();
+
+      const dispose = () => {
+        port1.close();
+        options.signal?.removeEventListener("abort", abortListener);
+      };
+
+      const abortListener = () => {
+        try {
+          port1.postMessage([ABORT_MESSAGE]);
+        } finally {
+          dispose();
+        }
+        reject(new Error("Aborted."));
+      };
+
+      port1.addEventListener("message", (event: MessageEvent<RpcEnvelope>) => {
+        const [tag, payload] = event.data;
+        if (tag === RESOLVE_MESSAGE) {
+          dispose();
+          resolve(payload as Result);
+        } else if (tag === REJECT_MESSAGE) {
+          dispose();
+          reject(payload);
+        }
+      });
+
+      if (options.signal) {
+        if (options.signal.aborted) {
+          abortListener();
+          return;
+        }
+        options.signal.addEventListener("abort", abortListener, { once: true });
+      }
+
+      const transfer = options.transfer ?? [];
+      port.postMessage([CALL_MESSAGE, ...args], [port2, ...transfer]);
+    });
+
+  call.withOptions = (callOptions) => makeCaller(port, callOptions);
+  return call;
+}
+
+export function createRpcEndpoint<Arguments extends unknown[], Result>(
+  port: MessagePort,
+  handler?: RpcHandler<Arguments, Result>,
+): RpcCaller<Arguments, Result> {
+  const listener = async (event: MessageEvent<RpcEnvelope>) => {
+    if (!isCallEnvelope(event.data)) return;
+    event.stopImmediatePropagation();
+
+    const [responsePort] = event.ports;
+    if (!responsePort) {
+      throw new Error("RPCCallMessage must contain a response port.");
+    }
+
+    responsePort.start();
+
+    if (!handler) {
+      responsePort.postMessage([
+        REJECT_MESSAGE,
+        new Error("No function registered for this RPC endpoint."),
+      ]);
+      responsePort.close();
+      return;
+    }
+
+    const abortController = new AbortController();
+    responsePort.addEventListener(
+      "message",
+      (messageEvent: MessageEvent<RpcEnvelope>) => {
+        if (isAbortEnvelope(messageEvent.data)) {
+          abortController.abort();
+        }
+      },
+      { once: true },
+    );
+
+    try {
+      const result = await handler.call({ signal: abortController.signal }, ...(event.data.slice(1) as Arguments));
+      try {
+        responsePort.postMessage([RESOLVE_MESSAGE, result]);
+      } catch (error) {
+        if (error instanceof Error && error.name === "DataCloneError") {
+          const clonedArgs = cloneForTransport(event.data.slice(1)) as Arguments;
+          const clonedResult = await handler.call({ signal: abortController.signal }, ...clonedArgs);
+          responsePort.postMessage([RESOLVE_MESSAGE, cloneForTransport(clonedResult)]);
+        } else {
+          throw error;
+        }
+      }
+    } catch (error) {
+      try {
+        responsePort.postMessage([REJECT_MESSAGE, cloneForTransport(error)]);
+      } catch (cloneError) {
+        responsePort.postMessage([
+          REJECT_MESSAGE,
+          cloneError instanceof Error ? cloneError : new Error(String(cloneError)),
+        ]);
+      }
+    } finally {
+      responsePort.close();
+    }
+  };
+
+  port.addEventListener("message", listener as EventListener);
+  port.start();
+
+  return makeCaller<Arguments, Result>(port, {});
+}
+
+export function createGeneratorRpcEndpoint<
+  Arguments extends unknown[],
+  Yield,
+  Return,
+  Next,
+>(
+  port: MessagePort,
+  handler?: (...args: Arguments) => AsyncGenerator<Yield, Return, Next>,
+): ((...args: Arguments) => AsyncGenerator<Yield, Return, Next>) & {
+  withOptions(options: RpcCallOptions): (...args: Arguments) => AsyncGenerator<Yield, Return, Next>;
+} {
+  port.addEventListener(
+    "message",
+    (event: MessageEvent<unknown>) => {
+      const payload = event.data;
+      if (!Array.isArray(payload) || payload[0] !== GENERATOR_MESSAGE) return;
+      event.stopImmediatePropagation();
+
+      if (!handler) {
+        throw new Error("No function registered for generator RPC endpoint.");
+      }
+
+      const [, ports, ...args] = payload as [typeof GENERATOR_MESSAGE, Record<string, MessagePort>, ...Arguments];
+      const iterator = handler(...(args as Arguments));
+
+      createRpcEndpoint(ports.next, iterator.next.bind(iterator));
+      createRpcEndpoint(ports.return, async (value: Next) => {
+        const finaliser = iterator.return?.bind(iterator);
+        return finaliser ? finaliser(value) : { done: true, value: undefined };
+      });
+      createRpcEndpoint(ports.throw, async (value: unknown) => {
+        const thrower = iterator.throw?.bind(iterator);
+        if (!thrower) throw value;
+        return thrower(value);
+      });
+
+      const asyncDispose = Symbol.asyncDispose ?? Symbol.for("Symbol.asyncDispose");
+      const syncDispose = Symbol.dispose ?? Symbol.for("Symbol.dispose");
+      createRpcEndpoint(ports.asyncDispose, async () => {
+        if (asyncDispose in iterator) {
+          await (iterator as Record<PropertyKey, () => Promise<void>>)[asyncDispose]?.();
+        } else if (syncDispose in iterator) {
+          (iterator as Record<PropertyKey, () => void>)[syncDispose]?.();
+        }
+      });
+    },
+  );
+  port.start();
+
+  const factory = (options: RpcCallOptions) => {
+    const caller = (...args: Arguments): AsyncGenerator<Yield, Return, Next> => {
+      const nextChannel = new MessageChannel();
+      const returnChannel = new MessageChannel();
+      const throwChannel = new MessageChannel();
+      const disposeChannel = new MessageChannel();
+
+      let closed = false;
+      let aborted = false;
+
+      const close = () => {
+        if (closed) return;
+        closed = true;
+        nextChannel.port1.close();
+        nextChannel.port2.close();
+        returnChannel.port1.close();
+        returnChannel.port2.close();
+        throwChannel.port1.close();
+        throwChannel.port2.close();
+        disposeChannel.port1.close();
+        disposeChannel.port2.close();
+      };
+
+      const ensureActive = () => {
+        if (aborted) {
+          throw new Error("This generator has been aborted.");
+        }
+        if (closed) {
+          throw new Error("This generator has been disposed.");
+        }
+      };
+
+      const baseOptions: RpcCallOptions = { signal: options.signal };
+      const next = createRpcEndpoint<[Next], IteratorResult<Yield, Return>>(nextChannel.port1).withOptions(baseOptions);
+      const complete = createRpcEndpoint<[Return], IteratorResult<Yield, Return>>(returnChannel.port1).withOptions(baseOptions);
+      const raise = createRpcEndpoint<[unknown], IteratorResult<Yield, Return>>(throwChannel.port1).withOptions(baseOptions);
+      const dispose = createRpcEndpoint<[], void>(disposeChannel.port1).withOptions(baseOptions);
+
+      const step = async <K extends "next" | "return" | "throw">(
+        rpc: RpcCaller<[unknown], IteratorResult<Yield, Return>>,
+        value: unknown,
+      ) => {
+        ensureActive();
+        const result = await rpc(value);
+        if (result?.done) {
+          close();
+        }
+        return result;
+      };
+
+      const iterator: AsyncGenerator<Yield, Return, Next> = {
+        next(value?: Next) {
+          return step(next as unknown as RpcCaller<[unknown], IteratorResult<Yield, Return>>, value);
+        },
+        return(value?: Return) {
+          return step(complete as unknown as RpcCaller<[unknown], IteratorResult<Yield, Return>>, value);
+        },
+        throw(value?: unknown) {
+          return step(raise as unknown as RpcCaller<[unknown], IteratorResult<Yield, Return>>, value);
+        },
+        [Symbol.asyncIterator]() {
+          return this;
+        },
+      };
+
+      const asyncDispose = Symbol.asyncDispose ?? Symbol.for("Symbol.asyncDispose");
+      (iterator as Record<PropertyKey, unknown>)[asyncDispose] = async () => {
+        ensureActive();
+        await dispose();
+        close();
+      };
+
+      if (options.signal) {
+        const abortListener = () => {
+          aborted = true;
+          close();
+        };
+        if (options.signal.aborted) {
+          abortListener();
+        } else {
+          options.signal.addEventListener("abort", abortListener, { once: true });
+        }
+      }
+
+      port.postMessage(
+        [
+          GENERATOR_MESSAGE,
+          {
+            asyncDispose: disposeChannel.port2,
+            next: nextChannel.port2,
+            return: returnChannel.port2,
+            throw: throwChannel.port2,
+          },
+          ...args,
+        ],
+        [
+          ...(options.transfer ?? []),
+          disposeChannel.port2,
+          nextChannel.port2,
+          returnChannel.port2,
+          throwChannel.port2,
+        ],
+      );
+
+      return iterator;
+    };
+
+    (caller as { withOptions: typeof factory }).withOptions = factory;
+    return caller;
+  };
+
+  const baseCaller = factory({});
+  (baseCaller as { withOptions: typeof factory }).withOptions = factory;
+  return baseCaller as typeof baseCaller & { withOptions: typeof factory };
+}

--- a/packages/oai/reversed/runHtml.ts
+++ b/packages/oai/reversed/runHtml.ts
@@ -1,0 +1,634 @@
+import { SandboxMessageType, EnvironmentLifecycleState, SandboxGlobalMap } from "./types";
+import { createAsyncIterator } from "./createAsyncIterator";
+import { setAdditionalGlobals } from "./additionalGlobals";
+import { installNavigationInstrumentation } from "./navigation";
+import { applySafeAreaVariables, SafeAreaDescriptor } from "./safeArea";
+import { applyTheme, ThemeName } from "./theme";
+import { SandboxLoggerLike } from "./sandboxLogger";
+import { ensureSandboxIframe, getSandboxIframe, instrumentSandboxInteractions } from "./sandboxFrame";
+import { getHostApi } from "./hostMessaging";
+import { LruCache } from "./lruCache";
+
+/**
+ * Reverse engineered entry point for executing HTML in the sandbox iframe.
+ *
+ * Minified identifier map from `run-html-Do8mTV6K.js`:
+ *   - `dt` → `runHTMLAsync`
+ *   - `Q` → `installImageSourceInterceptor`
+ *   - `Z` → `instrumentPointerMetrics`
+ *   - `z` → `instrumentConsole`
+ *   - `P` → `instrumentSecurityPolicyViolations`
+ *   - `Y` → `measureDocumentHeight`
+ *   - `X` → `discoverBackgroundColor`
+ */
+
+export interface PositionTransform {
+  line: number | null;
+  column: number | null;
+  source?: string | null;
+  name?: string | null;
+}
+
+export type PositionMapper = (position: { line: number | null; column: number | null }) => PositionTransform | null;
+
+export interface RunHtmlOptions {
+  sandboxLogger: SandboxLoggerLike;
+  html: string;
+  theme?: ThemeName;
+  safeArea?: SafeAreaDescriptor;
+  transformPosition?: PositionMapper | null;
+  additionalGlobals?: SandboxGlobalMap;
+  expectReadySignal?: boolean;
+}
+
+export type HtmlRunEvent =
+  | {
+      type: SandboxMessageType.ENVIRONMENT_STATUS;
+      status: EnvironmentLifecycleState;
+    }
+  | {
+      type: SandboxMessageType.RUN_COMPLETE;
+      duration: number | null;
+      wasCancelled: boolean;
+      wasFatalError: boolean;
+    }
+  | {
+      type: SandboxMessageType.ERROR;
+      line: number | null;
+      error: {
+        line: number | null;
+        message: string;
+        name: string;
+        stack: string[];
+      };
+    }
+  | {
+    type: SandboxMessageType.LOG;
+    level: "info" | "warn" | "error";
+    line: number | null;
+    log: unknown[];
+  };
+
+const TRANSPARENT_RGBA = /^rgba\(\s*(\d+),\s*(\d+),\s*(\d+),\s*([\d.]+)\s*\)$/;
+const DOWNLOAD_PROTOCOLS = ["sediment://", "file-service://"];
+const DOWNLOAD_PLACEHOLDER = "/blank.svg";
+const BASE_STYLES = `
+html,body,#root{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale}
+html,body{font-family:-apple-system,BlinkMacSystemFont,Segoe UI,Roboto,Oxygen,Ubuntu,Cantarell,Helvetica Neue,Arial,sans-serif!important}
+button,input,textarea,select{font-family:inherit}
+`.trim();
+
+const downloadCache = new LruCache<string, string>({ max: 100, ttl: 60 * 5_000 });
+
+const isFullyTransparent = (color: string): boolean => {
+  const match = color.match(TRANSPARENT_RGBA);
+  return match ? parseFloat(match[4]) === 0 : false;
+};
+
+function findFirstOpaqueBackground(root: Element): string | null {
+  const queue: Element[] = [root];
+
+  while (queue.length > 0) {
+    const element = queue.shift();
+    if (!element) break;
+
+    const { backgroundColor } = getComputedStyle(element);
+    if (!isFullyTransparent(backgroundColor) && backgroundColor !== "rgba(0, 0, 0, 0)") {
+      return backgroundColor;
+    }
+
+    for (const child of Array.from(element.children)) {
+      queue.push(child);
+    }
+  }
+
+  return null;
+}
+
+function measureElementHeight(element: Element | null | undefined): number | null {
+  if (!element) return null;
+  const scrollHeight = (element as HTMLElement).scrollHeight ?? 0;
+  const { height } = (element as HTMLElement).getBoundingClientRect();
+  const value = Math.max(scrollHeight, height);
+  return Number.isFinite(value) && value > 0 ? value : null;
+}
+
+function measureCompositeHeight(container: HTMLElement | null | undefined): number | null {
+  if (!container) return null;
+
+  const elements = Array.from(container.children).filter((child) => {
+    const tag = child.tagName;
+    return tag !== "SCRIPT" && tag !== "STYLE";
+  }) as HTMLElement[];
+
+  if (elements.length === 0) return null;
+  if (elements.length === 1) return measureElementHeight(elements[0]);
+
+  const hostBounds = container.getBoundingClientRect?.();
+  let maxHeight = 0;
+
+  for (const element of elements) {
+    const bounds = element.getBoundingClientRect?.();
+    if (!bounds) continue;
+    const baseline = hostBounds ? hostBounds.top : 0;
+    const candidate = bounds.bottom - baseline;
+    maxHeight = Math.max(maxHeight, candidate);
+  }
+
+  return maxHeight > 0 ? maxHeight : null;
+}
+
+function measureDocumentHeight(document: Document): number | null {
+  const root = document.getElementById("root");
+  if (root) {
+    const height = measureElementHeight(root) ?? measureCompositeHeight(root as HTMLElement);
+    if (height != null) return height;
+  }
+
+  const body = document.body;
+  if (body) {
+    const composite = measureCompositeHeight(body);
+    if (composite != null) return composite;
+
+    const bodyHeight = measureElementHeight(body);
+    if (bodyHeight != null) return bodyHeight;
+  }
+
+  return measureElementHeight(document.documentElement ?? document.scrollingElement);
+}
+
+function installImageSourceInterceptor(document: Document): void {
+  const contentWindow = document.defaultView;
+  if (!contentWindow) return;
+
+  const descriptor = Object.getOwnPropertyDescriptor(
+    contentWindow.HTMLImageElement.prototype,
+    "src",
+  );
+  if (!descriptor || !descriptor.set) return;
+
+  Object.defineProperty(contentWindow.HTMLImageElement.prototype, "src", {
+    configurable: true,
+    enumerable: true,
+    get: descriptor.get,
+    set(value: string) {
+      if (typeof value === "string" && DOWNLOAD_PROTOCOLS.some((prefix) => value.startsWith(prefix))) {
+        const cached = downloadCache.get(value);
+        if (cached) {
+          descriptor.set!.call(this, cached);
+          return;
+        }
+
+        descriptor.set!.call(this, DOWNLOAD_PLACEHOLDER);
+        getHostApi()
+          .getDownloadURL?.(value)
+          .then((resolved) => {
+            if (!resolved) return;
+            downloadCache.set(value, resolved);
+            descriptor.set!.call(this, resolved);
+          })
+          .catch(() => {
+            descriptor.set!.call(this, "");
+          });
+      } else {
+        descriptor.set!.call(this, value);
+      }
+    },
+  });
+}
+
+function instrumentPointerMetrics(document: Document): void {
+  const contentWindow = document.defaultView;
+  if (!contentWindow) return;
+
+  contentWindow.addEventListener(
+    "pointerdown",
+    (event) => {
+      for (const node of event.composedPath()) {
+        if (node instanceof contentWindow.HTMLElement && node.dataset.instrument) {
+          getHostApi().sendInstrument({
+            type: "count",
+            label: `clicked.${node.dataset.instrument}`,
+          });
+        }
+      }
+    },
+    { capture: true, passive: true },
+  );
+}
+
+function parseStackLocation(frame: string): { line: number | null; column: number | null } {
+  const match = frame.trim().match(/(\d+):(\d+)\)?$/);
+  if (!match) {
+    return { line: null, column: null };
+  }
+  return {
+    line: Number.parseInt(match[1] ?? "", 10) || null,
+    column: Number.parseInt(match[2] ?? "", 10) || null,
+  };
+}
+
+function formatStack(stack: string | undefined, mapper: PositionMapper | null | undefined): string[] {
+  if (!stack) return [];
+  const [, ...lines] = stack.split("\n");
+  const formatted: string[] = [];
+
+  for (const line of lines) {
+    const position = parseStackLocation(line);
+    const remapped = mapper?.(position) ?? position;
+    if (remapped.line == null || remapped.column == null) break;
+
+    formatted.push(`${line.replace(/\(.*\)/, "").trim()} (module:${remapped.line}:${remapped.column})`);
+  }
+
+  return formatted;
+}
+
+function instrumentConsole({
+  document,
+  sandboxLogger,
+  emit,
+  transformPosition,
+}: {
+  document: Document;
+  sandboxLogger: SandboxLoggerLike;
+  emit(event: HtmlRunEvent): void;
+  transformPosition?: PositionMapper | null;
+}): void {
+  const contentWindow = document.defaultView;
+  if (!contentWindow || !("console" in contentWindow)) {
+    return;
+  }
+
+  const remapLine = (line: number | null, column: number | null): number | null => {
+    if (!transformPosition) return line;
+    const result = transformPosition({ line, column });
+    return result?.line ?? line;
+  };
+
+  const forwardError = (message: string, error: unknown, line: number | null): void => {
+    if (error instanceof Error) {
+      emit({
+        type: SandboxMessageType.ERROR,
+        line,
+        error: {
+          line,
+          message: error.message,
+          name: error.name,
+          stack: formatStack(error.stack, transformPosition),
+        },
+      });
+    } else {
+      emit({
+        type: SandboxMessageType.ERROR,
+        line,
+        error: {
+          line,
+          message,
+          name: "Error",
+          stack: [],
+        },
+      });
+    }
+  };
+
+  contentWindow.addEventListener(
+    "unhandledrejection",
+    (event) => {
+      const reason = event.reason;
+      if (reason instanceof Error) {
+        const frames = formatStack(reason.stack, transformPosition);
+        const topLine = parseStackLocation(frames[0] ?? "").line;
+        emit({
+          type: SandboxMessageType.ERROR,
+          line: topLine ?? null,
+          error: {
+            line: topLine ?? null,
+            message: String(reason.message ?? ""),
+            name: reason.name ?? "Error",
+            stack: frames,
+          },
+        });
+      }
+    },
+    { passive: true, capture: true },
+  );
+
+  contentWindow.addEventListener(
+    "error",
+    (event: ErrorEvent) => {
+      const mapped = transformPosition?.({ line: event.lineno ?? null, column: event.colno ?? null });
+      const line = mapped?.line ?? event.lineno ?? null;
+
+      if (event.error instanceof Error) {
+        emit({
+          type: SandboxMessageType.ERROR,
+          line,
+          error: {
+            line,
+            message: event.error.message,
+            name: event.error.name,
+            stack: formatStack(event.error.stack, transformPosition),
+          },
+        });
+      } else {
+        emit({
+          type: SandboxMessageType.ERROR,
+          line,
+          error: {
+            line,
+            message: String(event.message ?? ""),
+            name: "Error",
+            stack: [],
+          },
+        });
+      }
+    },
+    { passive: true, capture: true },
+  );
+
+  const consoleObject = contentWindow.console;
+
+  const wrap = <T extends keyof Console>(method: T, forward: (payload: { line: number | null; args: unknown[]; error?: Error }) => void) => {
+    const original = consoleObject[method];
+    if (typeof original !== "function") return;
+
+    consoleObject[method] = ((first: unknown, ...rest: unknown[]) => {
+      const args = [first, ...rest];
+      let frameLine: string | undefined;
+
+      if (first instanceof Error && typeof first.stack === "string") {
+        const lines = first.stack.split("\n");
+        frameLine = lines[1] ?? lines[0];
+      } else {
+        const trace = new Error().stack ?? "";
+        frameLine = trace.split("\n")[2] ?? trace.split("\n")[1];
+      }
+
+      const location = parseStackLocation(frameLine ?? "");
+      const mappedLine = remapLine(location.line, location.column);
+
+      try {
+        forward({ line: mappedLine, args, error: first instanceof Error ? first : undefined });
+      } catch (error) {
+        sandboxLogger.error("Failed to forward console log", error);
+      }
+
+      return original.apply(consoleObject, args as []);
+    }) as Console[typeof method];
+  };
+
+  wrap("error", ({ line, args, error }) => {
+    if (error) {
+      forwardError(error.message, error, line);
+    } else {
+      emit({
+        type: SandboxMessageType.ERROR,
+        line,
+        error: {
+          line,
+          message: String(args[0] ?? ""),
+          name: "Error",
+          stack: [],
+        },
+      });
+    }
+
+    if (args.length > 0) {
+      emit({ type: SandboxMessageType.LOG, level: "info", line, log: args });
+    }
+  });
+
+  wrap("log", ({ line, args }) => {
+    emit({ type: SandboxMessageType.LOG, level: "info", line, log: args });
+  });
+}
+
+function instrumentSecurityPolicyViolations(document: Document): void {
+  const contentWindow = document.defaultView;
+  contentWindow?.addEventListener(
+    "securitypolicyviolation",
+    (event: SecurityPolicyViolationEvent) => {
+      getHostApi().notifySecurityPolicyViolation?.({
+        effectiveDirective: event.effectiveDirective,
+        violatedDirective: event.violatedDirective,
+        blockedURI: event.blockedURI,
+        sourceFile: event.sourceFile,
+      });
+    },
+  );
+}
+
+function injectBaseStyles(document: Document): void {
+  try {
+    const style = document.createElement("style");
+    style.textContent = BASE_STYLES;
+    document.head.appendChild(style);
+  } catch {
+    // Ignored – failing to inject helper styles is non-fatal.
+  }
+}
+
+function isIgnorableNode(node: Node): boolean {
+  if (node.nodeType === Node.COMMENT_NODE) return true;
+  if (node.nodeType === Node.TEXT_NODE) {
+    return !(node.textContent && node.textContent.trim());
+  }
+  if (node.nodeType === Node.ELEMENT_NODE) {
+    return node.childNodes.length === 0;
+  }
+  return true;
+}
+
+export async function* runHTMLAsync(options: RunHtmlOptions): AsyncIterableIterator<HtmlRunEvent> {
+  const {
+    sandboxLogger,
+    html,
+    theme,
+    safeArea,
+    transformPosition,
+    additionalGlobals,
+  } = options;
+
+  let resizeObserver: ResizeObserver | null = null;
+  let mutationObserver: MutationObserver | null = null;
+
+  const iterator = createAsyncIterator<HtmlRunEvent>(({ push, complete }) => {
+    const emit = (event: HtmlRunEvent) => {
+      push(event);
+      if (event.type === SandboxMessageType.RUN_COMPLETE) {
+        complete();
+      }
+    };
+
+    sandboxLogger.time("html.evaluation");
+
+    const previousIframe = getSandboxIframe();
+    const iframe = ensureSandboxIframe();
+
+    const handleLoad = () => {
+      const contentDocument = iframe.contentDocument;
+      const contentWindow = iframe.contentWindow;
+      if (!contentDocument || !contentWindow) {
+        return;
+      }
+
+      const globals: SandboxGlobalMap = { ...(additionalGlobals ?? {}) };
+      if (safeArea) {
+        globals.safeArea = safeArea;
+      }
+
+      if (Object.keys(globals).length > 0) {
+        setAdditionalGlobals({
+          iframe,
+          additionalGlobals: globals,
+          sandboxLogger,
+          overwriteExisting: true,
+        });
+      }
+
+      contentDocument.open();
+      instrumentSandboxInteractions(iframe);
+      installNavigationInstrumentation({ iframe });
+      instrumentSecurityPolicyViolations(contentDocument);
+      instrumentPointerMetrics(contentDocument);
+      instrumentConsole({
+        document: contentDocument,
+        sandboxLogger,
+        emit,
+        transformPosition,
+      });
+      installImageSourceInterceptor(contentDocument);
+
+      let lastBackground: string | null = null;
+      let lastHeight: number | null = null;
+
+      const notifyHeight = () => {
+        const height = measureDocumentHeight(contentDocument);
+        if (height != null && height !== lastHeight) {
+          getHostApi().notifyIntrinsicHeight?.(height);
+          lastHeight = height;
+        }
+      };
+
+      const notifyBackground = () => {
+        const color = findFirstOpaqueBackground(contentDocument.documentElement ?? contentDocument.body ?? null);
+        if (color && color !== lastBackground) {
+          getHostApi().notifyBackgroundColor?.(color);
+          lastBackground = color;
+        }
+      };
+
+      const finishInitialization = () => {
+        previousIframe?.remove();
+        sandboxLogger.timeEnd("html.evaluation");
+        emit({
+          type: SandboxMessageType.ENVIRONMENT_STATUS,
+          status: EnvironmentLifecycleState.RUNNING_CODE,
+        });
+      };
+
+      const abortWithFatalError = () => {
+        mutationObserver?.disconnect();
+        resizeObserver?.disconnect();
+        emit({
+          type: SandboxMessageType.RUN_COMPLETE,
+          duration: null,
+          wasCancelled: false,
+          wasFatalError: true,
+        });
+      };
+
+      resizeObserver = new ResizeObserver(() => {
+        notifyHeight();
+      });
+      if (contentDocument.documentElement) {
+        resizeObserver.observe(contentDocument.documentElement, { box: "border-box" });
+      }
+
+      mutationObserver = new MutationObserver((records) => {
+        for (const record of records) {
+          if (record.target === contentDocument.documentElement) {
+            if (
+              record.attributeName === "data-ready" &&
+              contentDocument.documentElement?.hasAttribute("data-ready")
+            ) {
+              finishInitialization();
+              break;
+            }
+            if (
+              record.attributeName === "data-fatal" &&
+              contentDocument.documentElement?.hasAttribute("data-fatal")
+            ) {
+              abortWithFatalError();
+              break;
+            }
+          } else if (
+            record.addedNodes.length === 0 &&
+            record.removedNodes.length > 0 &&
+            record.target.parentElement === contentDocument.body &&
+            record.target.childNodes.length === 0
+          ) {
+            const nodes = Array.from(contentDocument.body?.childNodes ?? []);
+            if (nodes.every((node) => node === record.target || isIgnorableNode(node))) {
+              abortWithFatalError();
+              break;
+            }
+          }
+        }
+
+        notifyBackground();
+        notifyHeight();
+      });
+
+      mutationObserver.observe(contentDocument.documentElement ?? contentDocument.body ?? contentDocument, {
+        attributes: true,
+        childList: true,
+        subtree: true,
+      });
+
+      const documentElement = contentDocument.documentElement;
+      if (documentElement && theme) {
+        applyTheme(iframe, theme);
+      }
+
+      if (safeArea) {
+        applySafeAreaVariables(iframe, safeArea);
+      }
+
+      injectBaseStyles(contentDocument);
+      contentDocument.write(html);
+      contentDocument.close();
+
+      finishInitialization();
+      if (documentElement?.hasAttribute("data-ready")) {
+        finishInitialization();
+      }
+
+      notifyBackground();
+      notifyHeight();
+    };
+
+    iframe.addEventListener("load", handleLoad, { once: true });
+    iframe.src = "about:blank";
+
+    if (iframe.parentElement) {
+      const removalObserver = new MutationObserver(() => {
+        if (!iframe.isConnected) {
+          removalObserver.disconnect();
+          resizeObserver?.disconnect();
+          mutationObserver?.disconnect();
+          emit({
+            type: SandboxMessageType.RUN_COMPLETE,
+            duration: null,
+            wasCancelled: false,
+            wasFatalError: false,
+          });
+        }
+      });
+      removalObserver.observe(iframe.parentElement, { childList: true, attributes: true, subtree: true });
+    }
+  });
+
+  yield* iterator;
+}

--- a/packages/oai/reversed/runWidgetCode.ts
+++ b/packages/oai/reversed/runWidgetCode.ts
@@ -1,0 +1,80 @@
+import { applyContentSecurityPolicy, CspConfiguration } from "./applyCsp";
+import { runHTMLAsync, RunHtmlOptions } from "./runHtml";
+import { getHostApi, locale } from "./hostMessaging";
+import { SandboxLoggerLike } from "./sandboxLogger";
+import { SafeAreaDescriptor } from "./safeArea";
+import { ThemeName } from "./theme";
+
+/**
+ * Re-creates the orchestration logic from `run-widget-code-BQGNBqus.js`.
+ */
+
+export interface RunWidgetCodeOptions {
+  html: string;
+  widgetId: string;
+  widgetState: unknown;
+  widgetProps?: unknown;
+  maxHeight?: number | null;
+  toolInput?: unknown;
+  toolOutput?: unknown;
+  toolResponseMetadata?: unknown;
+  displayMode?: string | null;
+  theme?: ThemeName;
+  userAgent?: string | null;
+  safeArea?: SafeAreaDescriptor;
+  csp?: CspConfiguration | null;
+}
+
+export async function* runWidgetCode(
+  logger: SandboxLoggerLike,
+  options: RunWidgetCodeOptions,
+): AsyncIterableIterator<unknown> {
+  try {
+    if (options.csp) {
+      applyContentSecurityPolicy(options.csp);
+    }
+  } catch (error) {
+    logger.error("Failed to apply CSP", error);
+    throw error;
+  }
+
+  let globals: Record<string, unknown> | undefined;
+  try {
+    const hostGlobals = getHostApi() as Record<string, unknown>;
+    hostGlobals.displayMode = options.displayMode ?? null;
+    hostGlobals.maxHeight = options.maxHeight ?? null;
+    hostGlobals.theme = options.theme ?? null;
+    hostGlobals.locale = locale;
+    hostGlobals.userAgent = options.userAgent ?? null;
+    hostGlobals.widget = {
+      state: options.widgetState,
+      props: options.widgetProps ?? options.toolOutput,
+      setState: (next: unknown) => {
+        const host = getHostApi();
+        return host.updateWidgetState?.(options.widgetId, next);
+      },
+    };
+    hostGlobals.toolInput = options.toolInput ?? null;
+    hostGlobals.toolOutput = options.toolOutput ?? null;
+    hostGlobals.widgetState = options.widgetState;
+    hostGlobals.setWidgetState = (next: unknown) => {
+      const host = getHostApi();
+      return host.updateWidgetState?.(options.widgetId, next);
+    };
+    hostGlobals.toolResponseMetadata = options.toolResponseMetadata ?? null;
+    globals = hostGlobals;
+  } catch (error) {
+    logger.error("Failed to prepare widget globals", error);
+  }
+
+  const iteratorOptions: RunHtmlOptions = {
+    sandboxLogger: logger,
+    html: options.html,
+    theme: options.theme,
+    safeArea: options.safeArea,
+    additionalGlobals: globals,
+    transformPosition: null,
+  };
+
+  yield* runHTMLAsync(iteratorOptions);
+}

--- a/packages/oai/reversed/safeArea.ts
+++ b/packages/oai/reversed/safeArea.ts
@@ -1,0 +1,37 @@
+/**
+ * Reverse engineered helper from `set-safe-area-vars-Bn-pRjCL.js`.
+ *
+ * Minified identifier map:
+ *   - `m` → `applySafeAreaVariables`
+ *   - `e` → `iframe`
+ *   - `r` → `safeArea`
+ *   - `t` → `documentElement`
+ *   - `o` → `safeArea.insets`
+ */
+
+export interface SafeAreaInsets {
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
+}
+
+export interface SafeAreaDescriptor {
+  insets: SafeAreaInsets;
+}
+
+export function applySafeAreaVariables(
+  iframe: HTMLIFrameElement | null | undefined,
+  safeArea: SafeAreaDescriptor,
+): void {
+  const documentElement = iframe?.contentDocument?.documentElement;
+  if (!documentElement) {
+    return;
+  }
+
+  const { top, bottom, left, right } = safeArea.insets;
+  documentElement.style.setProperty("--safe-area-inset-top", `${top}px`);
+  documentElement.style.setProperty("--safe-area-inset-bottom", `${bottom}px`);
+  documentElement.style.setProperty("--safe-area-inset-left", `${left}px`);
+  documentElement.style.setProperty("--safe-area-inset-right", `${right}px`);
+}

--- a/packages/oai/reversed/sandboxFrame.ts
+++ b/packages/oai/reversed/sandboxFrame.ts
@@ -1,0 +1,98 @@
+import { getHostApi, userActivationIsActive } from "./hostMessaging";
+
+/**
+ * Minified identifier map from `main-xonCUAoo.js`:
+ *   - `Ft` → `ROOT_IFRAME_ID`
+ *   - `rt` → `getSandboxIframe`
+ *   - `oe` → `removeSandboxIframe`
+ *   - `Pn` → `ensureSandboxIframe`
+ *   - `Mn` → `instrumentSandboxInteractions`
+ */
+
+export const ROOT_IFRAME_ID = "root";
+
+export function getSandboxIframe(): HTMLIFrameElement | null {
+  return document.getElementById(ROOT_IFRAME_ID) as HTMLIFrameElement | null;
+}
+
+export function removeSandboxIframe(): void {
+  getSandboxIframe()?.remove();
+}
+
+export function ensureSandboxIframe(): HTMLIFrameElement {
+  const existing = getSandboxIframe();
+  if (existing) return existing;
+
+  const iframe = document.createElement("iframe");
+  iframe.id = ROOT_IFRAME_ID;
+  document.body.appendChild(iframe);
+  return iframe;
+}
+
+function urlsMatch(origin: Location, href: string): boolean {
+  try {
+    const target = new URL(href, origin.href);
+    return target.hostname === origin.hostname && target.protocol === origin.protocol;
+  } catch {
+    return false;
+  }
+}
+
+export function instrumentSandboxInteractions(iframe: HTMLIFrameElement): void {
+  const contentWindow = iframe.contentWindow;
+  if (!contentWindow) return;
+
+  const host = getHostApi();
+
+  const openExternalIfNeeded = (targetHref: string) => {
+    if (!contentWindow.location) return;
+    if (!urlsMatch(contentWindow.location, targetHref)) {
+      host.openExternal?.({ href: targetHref });
+    }
+  };
+
+  const clickListener = (event: MouseEvent) => {
+    if (!event.isTrusted) return;
+    host.sendInstrument({ type: "interaction", label: "click" });
+
+    if (event.type !== "click") return;
+    const target = event.target as HTMLElement | null;
+    if (!target) return;
+
+    const anchor = target.closest<HTMLAnchorElement>("a");
+    if (!anchor || !anchor.getAttribute("href")) return;
+
+    const href = anchor.getAttribute("href")!;
+    if (!urlsMatch(contentWindow.location, href)) {
+      openExternalIfNeeded(href);
+      event.preventDefault();
+    }
+  };
+
+  const keydownListener = (event: KeyboardEvent) => {
+    if (event.key === "Escape") {
+      host.notifyEscapeKey?.();
+    }
+  };
+
+  contentWindow.addEventListener("click", clickListener, { capture: true });
+  contentWindow.addEventListener("keydown", keydownListener, { passive: true });
+
+  contentWindow.open = (href?: string | URL, target?: string, features?: string) => {
+    if (!href) return null;
+    openExternalIfNeeded(String(href));
+    return null;
+  };
+}
+
+export function guardUserGesture<T extends (...args: unknown[]) => unknown>(
+  callback: T,
+): T {
+  return (((...args: unknown[]) => {
+    if (!userActivationIsActive()) {
+      console.warn("Host API method invoked without a synchronous user gesture.");
+      return undefined;
+    }
+    return callback(...(args as Parameters<T>));
+  }) as unknown) as T;
+}

--- a/packages/oai/reversed/sandboxLogger.ts
+++ b/packages/oai/reversed/sandboxLogger.ts
@@ -1,0 +1,91 @@
+import { SandboxMessageType } from "./types";
+import { getHostApi } from "./hostMessaging";
+
+/**
+ * Minified identifier map from `main-xonCUAoo.js`:
+ *   - `N` → `SandboxLogger`
+ */
+
+export interface InstrumentationEvent {
+  type: "count" | "hist" | "interaction" | "error";
+  label?: string;
+  value?: number;
+  count?: number;
+  tags?: Record<string, string | number>;
+  message?: string;
+  error?: unknown;
+}
+
+function now(): number {
+  return typeof performance !== "undefined" ? performance.now() : Date.now();
+}
+
+export class SandboxLogger {
+  private readonly pendingTimers = new Map<string, number>();
+
+  log(...message: unknown[]): void {
+    console.log("[sandbox]", ...message);
+  }
+
+  error(message: string, error: unknown): void {
+    console.error("[sandbox]", message, error);
+    try {
+      getHostApi().sendInstrument({ type: "error", message, error });
+    } catch {
+      // The host bridge is not ready yet, fall back to console logging only.
+    }
+  }
+
+  environmentError(error: unknown): void {
+    console.error("[sandbox]", error);
+
+    const host = getHostApi();
+    if (error instanceof Error) {
+      const { name, message, stack } = error;
+      host.notifyEnvironmentError({ name, message, stack: stack ?? null });
+      return;
+    }
+
+    const fallbackStack = new Error().stack ?? null;
+    try {
+      host.notifyEnvironmentError({
+        name: "Unknown environment error",
+        message: JSON.stringify(error),
+        stack: fallbackStack,
+      });
+    } catch {
+      host.notifyEnvironmentError({
+        name: "Unknown environment error",
+        message: "Failed to stringify error",
+        stack: fallbackStack,
+      });
+    }
+  }
+
+  count(label: string, count = 1, tags?: Record<string, string | number>): void {
+    getHostApi().sendInstrument({ type: "count", label, count, tags });
+  }
+
+  time(label: string): void {
+    this.pendingTimers.set(label, now());
+  }
+
+  timeEnd(label: string): void {
+    const started = this.pendingTimers.get(label);
+    if (started == null) return;
+    this.pendingTimers.delete(label);
+
+    const duration = now() - started;
+    getHostApi().sendInstrument({ type: "hist", label, value: duration });
+  }
+
+  emitLifecycle(state: SandboxMessageType): void {
+    getHostApi().sendInstrument({ type: "count", label: state });
+  }
+}
+
+export type SandboxLoggerLike = Pick<
+  SandboxLogger,
+  "log" | "error" | "environmentError" | "count" | "time" | "timeEnd"
+>;
+

--- a/packages/oai/reversed/theme.ts
+++ b/packages/oai/reversed/theme.ts
@@ -1,0 +1,23 @@
+/**
+ * Reverse engineered helper from `set-theme-Cu8raYyE.js`.
+ *
+ * Minified identifier map:
+ *   - `o` → `applyTheme`
+ *   - `s` → `theme`
+ *   - `e` → `iframe`
+ *   - `t` → `documentElement`
+ */
+
+export type ThemeName = "light" | "dark" | (string & {});
+
+export function applyTheme(
+  iframe: HTMLIFrameElement | null | undefined,
+  theme: ThemeName,
+): void {
+  const documentElement = iframe?.contentDocument?.documentElement;
+  if (!documentElement) return;
+
+  documentElement.dataset.theme = theme;
+  documentElement.classList.remove("light", "dark");
+  documentElement.classList.add(theme);
+}

--- a/packages/oai/reversed/types.ts
+++ b/packages/oai/reversed/types.ts
@@ -1,0 +1,62 @@
+/**
+ * Reverse engineered type declarations extracted from the minified
+ * `types-Bm40F6nV.js` bundle.
+ *
+ * Minified identifier map:
+ *   - `A` → `SandboxMessageType`
+ *   - `G` → `EnvironmentLifecycleState`
+ *   - `r` → `WebPlusGlobalsEvent`
+ *   - `c` → `OpenAIGlobalsEvent`
+ */
+
+/**
+ * Wire protocol messages emitted by the sandbox when executing code.
+ */
+export enum SandboxMessageType {
+  LOG = "log",
+  RUN_START = "run_start",
+  ENVIRONMENT_STATUS = "environment_status",
+  OUTPUT = "output",
+  ERROR = "error",
+  RUN_COMPLETE = "run_complete",
+}
+
+/**
+ * High level status values reported while the sandbox prepares or runs code.
+ */
+export enum EnvironmentLifecycleState {
+  INITIALIZING,
+  INSTALLING_PACKAGES,
+  RUNNING_CODE,
+}
+
+const WEBPLUS_GLOBALS_EVENT = "webplus:set_globals" as const;
+const OPENAI_GLOBALS_EVENT = "openai:set_globals" as const;
+
+export interface SandboxGlobalMap {
+  [globalName: string]: unknown;
+}
+
+/**
+ * Event dispatched when the sandbox wants to expose globals under the
+ * historic `webplus` namespace.
+ */
+export class WebPlusGlobalsEvent extends CustomEvent<{ globals: SandboxGlobalMap }> {
+  constructor(globals: SandboxGlobalMap) {
+    super(WEBPLUS_GLOBALS_EVENT, { detail: { globals } });
+    // Align the public `type` property with the event name even in older
+    // browsers that do not allow overriding it via the constructor.
+    (this as { type: string }).type = WEBPLUS_GLOBALS_EVENT;
+  }
+}
+
+/**
+ * Event dispatched when the sandbox wants to expose globals under the
+ * `openai` namespace.
+ */
+export class OpenAIGlobalsEvent extends CustomEvent<{ globals: SandboxGlobalMap }> {
+  constructor(globals: SandboxGlobalMap) {
+    super(OPENAI_GLOBALS_EVENT, { detail: { globals } });
+    (this as { type: string }).type = OPENAI_GLOBALS_EVENT;
+  }
+}


### PR DESCRIPTION
## Summary
- catalog the sandbox and host RPC endpoints with detailed descriptions and handshake docs for the iframe bridge
- extend the HostApi typings to include completion and follow-up helpers used by the parent shell
- add a React SandboxParentBridge component that negotiates the MessageChannel wiring and streams widget events to the host

## Testing
- npm run -s tsc -- --noEmit

------
https://chatgpt.com/codex/tasks/task_e_68e753ee5778832db722e4bdee8eef9d