### PR TITLE
feat: add toolResponseMetadata support to WidgetDisplayComponent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8334,7 +8334,8 @@
       }
     },
     "packages/oai-preview": {
-      "version": "1.0.0",
+      "name": "@fractal-mcp/oai-preview",
+      "version": "1.0.1",
       "devDependencies": {
         "@types/jest": "^29.0.0",
         "@types/node": "^20.0.0",

--- a/packages/oai-preview/package.json
+++ b/packages/oai-preview/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractal-mcp/oai-preview",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "React component for previewing OpenAI Apps SDK widgets in development",
   "repository": {
     "type": "git",
@@ -43,4 +43,3 @@
     "react-dom": "^18.0.0"
   }
 }
-


### PR DESCRIPTION
In addition to `toolInput`, and `toolOutput` openAI docs show support for `toolResponseMetadata` on the window.openai object (https://developers.openai.com/apps-sdk/build/custom-ux/). This PR adds support for `toolResponseMetadata` to the `WidgetDisplayComponent`.