### PR TITLE
Add release-triggered CI workflow

### DIFF
--- a/.github/workflows/release-ci.yml
+++ b/.github/workflows/release-ci.yml
@@ -1,0 +1,35 @@
+name: Release Validation CI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  test:
+    name: Test & Lint
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Fix optional dependencies (Rollup)
+        run: npm install --no-save @rollup/rollup-linux-x64-gnu
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: Run tests
+        run: npm run test
+
+      - name: Run linter
+        run: npm run lint


### PR DESCRIPTION
## Summary
- add a release validation workflow that triggers when a release is published
- reuse the existing CI steps to run tests and linting on release events

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f2f9f7a82c832db8ece7338e91230c