### PR TITLE
feat: add oai-client package for OpenAI widget MCP clients

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -103,6 +103,52 @@
         "loose-envify": "^1.1.0"
       }
     },
+    "node_modules/@ai-sdk/gateway": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/gateway/-/gateway-2.0.0.tgz",
+      "integrity": "sha512-Gj0PuawK7NkZuyYgO/h5kDK/l6hFOjhLdTq3/Lli1FTl47iGmwhH1IZQpAL3Z09BeFYWakcwUmn02ovIm2wy9g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.0",
+        "@ai-sdk/provider-utils": "3.0.12",
+        "@vercel/oidc": "3.0.3"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
+    "node_modules/@ai-sdk/provider": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider/-/provider-2.0.0.tgz",
+      "integrity": "sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "json-schema": "^0.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@ai-sdk/provider-utils": {
+      "version": "3.0.12",
+      "resolved": "https://registry.npmjs.org/@ai-sdk/provider-utils/-/provider-utils-3.0.12.tgz",
+      "integrity": "sha512-ZtbdvYxdMoria+2SlNarEk6Hlgyf+zzcznlD55EAl+7VZvJaSg2sqPvwArY7L6TfDEDJsnCq0fdhBSkYo0Xqdg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/provider": "2.0.0",
+        "@standard-schema/spec": "^1.0.0",
+        "eventsource-parser": "^3.0.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
+      }
+    },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
       "dev": true,
@@ -745,6 +791,10 @@
       "resolved": "packages/mcp-ui-messenger",
       "link": true
     },
+    "node_modules/@fractal-mcp/oai-client": {
+      "resolved": "packages/oai-client",
+      "link": true
+    },
     "node_modules/@fractal-mcp/oai-hooks": {
       "resolved": "packages/oai-hooks",
       "link": true
@@ -1249,6 +1299,15 @@
         "node": ">= 8"
       }
     },
+    "node_modules/@opentelemetry/api": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/@opentelemetry/api/-/api-1.9.0.tgz",
+      "integrity": "sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
       "license": "MIT"
@@ -1284,6 +1343,12 @@
       "dependencies": {
         "@sinonjs/commons": "^3.0.0"
       }
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
+      "integrity": "sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==",
+      "license": "MIT"
     },
     "node_modules/@sveltejs/vite-plugin-svelte": {
       "version": "3.1.2",
@@ -2033,6 +2098,15 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/@vercel/oidc": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@vercel/oidc/-/oidc-3.0.3.tgz",
+      "integrity": "sha512-yNEQvPcVrK9sIe637+I0jD6leluPxzwJKx/Haw6F4H77CdDsszUn5V3o96LPziXkSNE2B83+Z3mjqGKBK/R6Gg==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 20"
+      }
+    },
     "node_modules/@vitejs/plugin-react": {
       "version": "4.7.0",
       "license": "MIT",
@@ -2169,6 +2243,24 @@
       "license": "MIT",
       "peerDependencies": {
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
+      }
+    },
+    "node_modules/ai": {
+      "version": "5.0.76",
+      "resolved": "https://registry.npmjs.org/ai/-/ai-5.0.76.tgz",
+      "integrity": "sha512-ZCxi1vrpyCUnDbtYrO/W8GLvyacV9689f00yshTIQ3mFFphbD7eIv40a2AOZBv3GGRA7SSRYIDnr56wcS/gyQg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@ai-sdk/gateway": "2.0.0",
+        "@ai-sdk/provider": "2.0.0",
+        "@ai-sdk/provider-utils": "3.0.12",
+        "@opentelemetry/api": "1.9.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.76 || ^4.1.8"
       }
     },
     "node_modules/ajv": {
@@ -5114,6 +5206,12 @@
       "version": "2.3.1",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/json-schema": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
+      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
+      "license": "(AFL-2.1 OR BSD-3-Clause)"
     },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
@@ -8710,6 +8808,32 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/oai-client": {
+      "name": "@fractal-mcp/oai-client",
+      "version": "1.0.0",
+      "dependencies": {
+        "@modelcontextprotocol/sdk": "^1.0.0",
+        "ai": "^5.0.76"
+      },
+      "devDependencies": {
+        "@types/jest": "^29.5.14",
+        "@types/node": "^20.0.0",
+        "eslint": "^9.0.0",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.4.0",
+        "typescript": "^5.0.0"
+      }
+    },
+    "packages/oai-client/node_modules/@types/node": {
+      "version": "20.19.22",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.22.tgz",
+      "integrity": "sha512-hRnu+5qggKDSyWHlnmThnUqg62l29Aj/6vcYgUaSFL9oc7DVjeWEQN3PRgdSc6F8d9QRMWkf36CLMch1Do/+RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
       }
     },
     "packages/oai-hooks": {

--- a/packages/oai-client/jest.config.cjs
+++ b/packages/oai-client/jest.config.cjs
@@ -1,0 +1,11 @@
+module.exports = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  extensionsToTreatAsEsm: ['.ts'],
+  moduleFileExtensions: ['ts', 'tsx', 'js'],
+  transform: {
+    '^.+\\.tsx?$': ['ts-jest', { useESM: true }]
+  },
+  rootDir: './',
+  testMatch: ['**/?(*.)+(spec|test).[tj]s?(x)']
+};

--- a/packages/oai-client/package.json
+++ b/packages/oai-client/package.json
@@ -1,0 +1,42 @@
+{
+  "name": "@fractal-mcp/oai-client",
+  "version": "1.0.0",
+  "description": "MCP client wrapper for OpenAI widget-enabled servers",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/fractal-mcp/sdk.git"
+  },
+  "type": "module",
+  "types": "./dist/index.d.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "clean": "rm -rf dist",
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
+    "test": "node --experimental-vm-modules --no-warnings ../../node_modules/jest/bin/jest.js"
+  },
+  "files": [
+    "dist",
+    "src"
+  ],
+  "dependencies": {
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "ai": "^5.0.76"
+  },
+  "devDependencies": {
+    "@types/jest": "^29.5.14",
+    "@types/node": "^20.0.0",
+    "eslint": "^9.0.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/oai-client/src/index.test.ts
+++ b/packages/oai-client/src/index.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it, jest } from "@jest/globals";
+import type { ReadResourceResult } from "@modelcontextprotocol/sdk/types.js";
+
+import { resolveResourceMetadata } from "./index";
+
+describe("resolveResourceMetadata", () => {
+  it("returns undefined when no resource references are present", async () => {
+    const meta = { "openai/toolInvocation/invoked": "done" };
+    const reader = jest.fn<(uri: string) => Promise<ReadResourceResult>>();
+
+    const result = await resolveResourceMetadata(meta, reader);
+
+    expect(result).toBeUndefined();
+    expect(reader).not.toHaveBeenCalled();
+  });
+
+  it("resolves widget HTML and records resolved resources", async () => {
+    const templateUri = "ui://widget/example.html";
+    const meta = {
+      "openai/outputTemplate": templateUri,
+      "openai/toolInvocation/invoking": "Loading"
+    };
+    const html = "<div>widget</div>";
+    const reader = jest.fn<(uri: string) => Promise<ReadResourceResult>>();
+    reader.mockResolvedValue({
+      contents: [
+        {
+          uri: templateUri,
+          text: html
+        }
+      ]
+    } as ReadResourceResult);
+
+    const result = await resolveResourceMetadata(meta, reader);
+
+    expect(result).not.toBeUndefined();
+    expect(result).not.toBe(meta);
+    const widgetHtml = result?.["openai/widgetHtml"] as string | undefined;
+    const resolvedResources = result?.["fractal/resolvedResources"] as
+      | Record<string, string>
+      | undefined;
+
+    expect(widgetHtml).toBe(html);
+    expect(resolvedResources).toEqual({
+      [templateUri]: html
+    });
+    expect(meta).not.toHaveProperty("openai/widgetHtml");
+  });
+
+  it("ignores resources that do not contain text content", async () => {
+    const templateUri = "ui://widget/empty.html";
+    const meta = {
+      "openai/outputTemplate": templateUri
+    };
+    const reader = jest.fn<(uri: string) => Promise<ReadResourceResult>>();
+    reader.mockResolvedValue({
+      contents: [
+        {
+          uri: templateUri
+        }
+      ]
+    } as ReadResourceResult);
+
+    const result = await resolveResourceMetadata(meta, reader);
+
+    expect(result).toBeUndefined();
+    expect(reader).toHaveBeenCalledWith(templateUri);
+  });
+});

--- a/packages/oai-client/src/index.ts
+++ b/packages/oai-client/src/index.ts
@@ -1,0 +1,254 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import {
+  SSEClientTransport,
+  type SSEClientTransportOptions
+} from "@modelcontextprotocol/sdk/client/sse.js";
+import type {
+  CallToolResult,
+  Implementation,
+  ListToolsResult,
+  ReadResourceResult
+} from "@modelcontextprotocol/sdk/types.js";
+import { jsonSchema, type JSONSchema7, type Tool as VercelTool } from "ai";
+
+const DEFAULT_CLIENT_INFO: Implementation = {
+  name: "@fractal-mcp/oai-client",
+  version: "1.0.0"
+};
+
+const DEFAULT_SSE_PATH = "/mcp";
+const RESOLVED_RESOURCES_KEY = "fractal/resolvedResources";
+const OUTPUT_TEMPLATE_KEY = "openai/outputTemplate";
+const WIDGET_HTML_KEY = "openai/widgetHtml";
+
+type MetadataRecord = Record<string, unknown>;
+
+type ResourceReference = {
+  key: string;
+  uri: string;
+};
+
+function toUrl(input: string | URL): URL {
+  return input instanceof URL ? new URL(input.toString()) : new URL(input);
+}
+
+function isRecord(value: unknown): value is MetadataRecord {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function looksLikeWidgetUri(value: unknown): value is string {
+  return typeof value === "string" && value.startsWith("ui://");
+}
+
+function isTextContent(content: ReadResourceResult["contents"][number]): content is ReadResourceResult["contents"][number] & {
+  text: string;
+} {
+  return "text" in content && typeof content.text === "string";
+}
+
+function collectResourceReferences(meta: MetadataRecord): ResourceReference[] {
+  const references: ResourceReference[] = [];
+  for (const [key, value] of Object.entries(meta)) {
+    if (looksLikeWidgetUri(value)) {
+      references.push({ key, uri: value });
+    }
+  }
+  return references;
+}
+
+async function fetchResourceText(
+  reader: (uri: string) => Promise<ReadResourceResult>,
+  uri: string
+): Promise<string | undefined> {
+  const result = await reader(uri);
+  for (const content of result.contents) {
+    if (isTextContent(content)) {
+      return content.text;
+    }
+  }
+  return undefined;
+}
+
+function mergeResolvedResources(
+  original: unknown,
+  updates: Map<string, string>
+): Record<string, string> {
+  const base: Record<string, string> = isRecord(original)
+    ? Object.fromEntries(
+        Object.entries(original).filter((entry): entry is [string, string] => typeof entry[1] === "string")
+      )
+    : {};
+  for (const [uri, text] of updates.entries()) {
+    base[uri] = text;
+  }
+  return base;
+}
+
+/**
+ * Resolve metadata resource references and return an updated metadata record.
+ *
+ * @returns A new metadata record when references were resolved, otherwise undefined.
+ */
+export async function resolveResourceMetadata(
+  meta: MetadataRecord,
+  reader: (uri: string) => Promise<ReadResourceResult>
+): Promise<MetadataRecord | undefined> {
+  const references = collectResourceReferences(meta);
+  if (references.length === 0) {
+    return undefined;
+  }
+
+  const resolvedTexts = new Map<string, string>();
+  for (const reference of references) {
+    if (resolvedTexts.has(reference.uri)) {
+      continue;
+    }
+    const text = await fetchResourceText(reader, reference.uri);
+    if (text !== undefined) {
+      resolvedTexts.set(reference.uri, text);
+    }
+  }
+
+  if (resolvedTexts.size === 0) {
+    return undefined;
+  }
+
+  const updatedMeta: MetadataRecord = { ...meta };
+  updatedMeta[RESOLVED_RESOURCES_KEY] = mergeResolvedResources(
+    meta[RESOLVED_RESOURCES_KEY],
+    resolvedTexts
+  );
+
+  const templateHtml = resolvedTexts.get(meta[OUTPUT_TEMPLATE_KEY] as string);
+  if (
+    templateHtml !== undefined &&
+    (updatedMeta[WIDGET_HTML_KEY] === undefined || typeof updatedMeta[WIDGET_HTML_KEY] !== "string")
+  ) {
+    updatedMeta[WIDGET_HTML_KEY] = templateHtml;
+  }
+
+  return updatedMeta;
+}
+
+export type ProcessedToolResult = CallToolResult & {
+  _meta?: MetadataRecord & {
+    [RESOLVED_RESOURCES_KEY]?: Record<string, string>;
+    [WIDGET_HTML_KEY]?: string;
+  };
+};
+
+export interface OpenAIClientOptions {
+  /** Base URL for the OpenAI app server. */
+  url: string | URL;
+  /** Optional SSE path (defaults to "/mcp"). */
+  ssePath?: string;
+  /** Custom client identification information. */
+  clientInfo?: Implementation;
+  /** Additional options for the SSE transport. */
+  transportOptions?: SSEClientTransportOptions;
+}
+
+type ToolList = ListToolsResult["tools"];
+
+export type VercelCompatibleTool = VercelTool<Record<string, unknown>, ProcessedToolResult>;
+
+export class OpenAIClient {
+  private readonly client: Client;
+  private readonly baseUrl: URL;
+  private toolCache?: ToolList;
+
+  private constructor(
+    client: Client,
+    baseUrl: URL
+  ) {
+    this.client = client;
+    this.baseUrl = baseUrl;
+  }
+
+  static async connect(options: OpenAIClientOptions): Promise<OpenAIClient> {
+    const baseUrl = toUrl(options.url);
+    const ssePath = options.ssePath ?? DEFAULT_SSE_PATH;
+    const sseUrl = new URL(ssePath, baseUrl);
+    const client = new Client(options.clientInfo ?? DEFAULT_CLIENT_INFO);
+    const transport = new SSEClientTransport(sseUrl, options.transportOptions);
+    await client.connect(transport);
+    return new OpenAIClient(client, baseUrl);
+  }
+
+  get url(): URL {
+    return this.baseUrl;
+  }
+
+  async close(): Promise<void> {
+    await this.client.close();
+  }
+
+  private async ensureTools(forceRefresh = false): Promise<ToolList> {
+    if (!this.toolCache || forceRefresh) {
+      const { tools } = await this.client.listTools();
+      this.toolCache = tools;
+    }
+    return this.toolCache;
+  }
+
+  async listTools(forceRefresh = false): Promise<ToolList> {
+    return this.ensureTools(forceRefresh);
+  }
+
+  async callTool(
+    name: string,
+    args?: Record<string, unknown>
+  ): Promise<ProcessedToolResult> {
+    await this.ensureTools();
+    const result = (await this.client.callTool({
+      name,
+      arguments: args
+    })) as CallToolResult;
+
+    if (!result._meta) {
+      return result;
+    }
+
+    const enrichedMeta = await resolveResourceMetadata(result._meta, async (uri) =>
+      this.client.readResource({ uri })
+    );
+
+    if (!enrichedMeta) {
+      return result;
+    }
+
+    return {
+      ...result,
+      _meta: enrichedMeta
+    };
+  }
+
+  async toVercelTools(): Promise<Record<string, VercelCompatibleTool>> {
+    const tools = await this.ensureTools();
+    const toolEntries = tools.map((tool) => {
+      const schema = (tool.inputSchema ?? {
+        type: "object",
+        properties: {},
+        additionalProperties: true
+      }) as JSONSchema7;
+
+      const execute: VercelCompatibleTool["execute"] = async (input, options) => {
+        void options; // Options are currently unused but retained for signature compatibility.
+        const args = isRecord(input) ? (input as Record<string, unknown>) : {};
+        return this.callTool(tool.name, args);
+      };
+
+      const vercelTool: VercelCompatibleTool = {
+        description: tool.description ?? undefined,
+        inputSchema: jsonSchema(schema),
+        execute
+      };
+
+      return [tool.name, vercelTool] as const;
+    });
+
+    return Object.fromEntries(toolEntries);
+  }
+}
+
+export default OpenAIClient;

--- a/packages/oai-client/tsconfig.json
+++ b/packages/oai-client/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "Node",
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "allowSyntheticDefaultImports": true,
+    "resolveJsonModule": true
+  },
+  "include": [
+    "src/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "dist",
+    "**/*.test.ts",
+    "**/*.spec.ts"
+  ]
+}


### PR DESCRIPTION
## Summary
- add the new `@fractal-mcp/oai-client` package with an `OpenAIClient` wrapper for SSE-based MCP servers
- resolve widget resource metadata to expose HTML in tool results and provide Vercel AI SDK-compatible tool adapters
- cover resource resolution helpers with Jest tests

## Testing
- npm run build -- --filter=@fractal-mcp/oai-client
- npm run test -- --filter=@fractal-mcp/oai-client

------
https://chatgpt.com/codex/tasks/task_e_68f2f78b20a0832da204dca3951429a5