### PR TITLE
chore: rename message port transport and document test helper

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -771,6 +771,10 @@
       "resolved": "packages/test-utils-mcp",
       "link": true
     },
+    "node_modules/@fractal-mcp/transports": {
+      "resolved": "packages/transports",
+      "link": true
+    },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
       "dev": true,
@@ -10042,6 +10046,30 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/transports": {
+      "name": "@fractal-mcp/transports",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@fractal-mcp/test-utils-mcp": "^1.0.0",
+        "@modelcontextprotocol/sdk": "^1.0.0",
+        "@types/jest": "^29.5.14",
+        "@types/node": "^20.0.0",
+        "eslint": "^9.37.0",
+        "jest": "^29.7.0",
+        "ts-jest": "^29.4.0",
+        "typescript": "^5.0.0"
+      }
+    },
+    "packages/transports/node_modules/@types/node": {
+      "version": "20.19.22",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.22.tgz",
+      "integrity": "sha512-hRnu+5qggKDSyWHlnmThnUqg62l29Aj/6vcYgUaSFL9oc7DVjeWEQN3PRgdSc6F8d9QRMWkf36CLMch1Do/+RQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
       }
     }
   }

--- a/packages/test-utils-mcp/README.md
+++ b/packages/test-utils-mcp/README.md
@@ -52,6 +52,18 @@ await testHelloMcpServerSessionOverSse("http://localhost:3000");
 await testHelloMcpServerSessionOverStreamableHttp("http://localhost:3000");
 ```
 
+## Tool invocation checks
+
+When you only need to validate that a server exposes the `sayHello` tool and can invoke
+it successfully, use the basic operations helper. This exercises tool discovery and a
+single JSON-RPC call without asserting any session behavior.
+
+```ts
+import { testHelloMcpServerBasicOperations } from "@fractal-mcp/test-utils-mcp";
+
+await testHelloMcpServerBasicOperations(client);
+```
+
 ## Local example servers
 
 The package also exports MCP server factories so you can host known-good servers using

--- a/packages/test-utils-mcp/src/index.ts
+++ b/packages/test-utils-mcp/src/index.ts
@@ -14,3 +14,4 @@ export { testMcpServerCanHandleSSE } from "./testcases/testMcpServerCanHandleSSE
 export { testMcpServerCanHandleStreamableHttp } from "./testcases/testMcpServerCanHandleStreamableHttp.js";
 export { testHelloMcpServerSessionOverSse } from "./testcases/testHelloMcpServerSessionOverSse.js";
 export { testHelloMcpServerSessionOverStreamableHttp } from "./testcases/testHelloMcpServerSessionOverStreamableHttp.js";
+export { testHelloMcpServerBasicOperations } from "./testcases/testHelloMcpServerBasicOperations.js";

--- a/packages/test-utils-mcp/src/testcases/testHelloMcpServerBasicOperations.ts
+++ b/packages/test-utils-mcp/src/testcases/testHelloMcpServerBasicOperations.ts
@@ -1,0 +1,39 @@
+import assert from "node:assert";
+
+import type { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import type { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
+
+type HelloTestClient = Pick<Client, "listTools" | "callTool">;
+
+type ToolListResult = Awaited<ReturnType<HelloTestClient["listTools"]>>;
+
+function assertHasSayHelloTool(result: ToolListResult): void {
+  const { tools } = result as { tools?: Array<Record<string, unknown>> };
+  assert(Array.isArray(tools), "Expected tool list to be an array");
+  const toolNames = tools.map((tool) => tool?.name).filter((name): name is string => typeof name === "string");
+  assert(
+    toolNames.includes("sayHello"),
+    `Expected sayHello tool to be present, got: ${toolNames.join(", ")}`
+  );
+}
+
+function assertHelloResponse(result: CallToolResult): void {
+  const { content } = result;
+  assert(Array.isArray(content), "Expected tool result content to be an array");
+  assert(content.length > 0, "Expected tool result content to include a text item");
+  const first = content[0];
+  assert(first && typeof first === "object" && !Array.isArray(first), "Expected tool result content to be an object");
+  const { type, text } = first as { type?: unknown; text?: unknown };
+  assert.strictEqual(type, "text", "Expected tool result content type to be text");
+  assert.strictEqual(text, "Hello from the test MCP server!", "Unexpected tool response text");
+}
+
+export async function testHelloMcpServerBasicOperations(client: HelloTestClient): Promise<void> {
+  const toolList = await client.listTools();
+  assertHasSayHelloTool(toolList);
+  const sayHelloResult = (await client.callTool({
+    name: "sayHello",
+    arguments: {}
+  })) as CallToolResult;
+  assertHelloResponse(sayHelloResult);
+}

--- a/packages/transports/README.md
+++ b/packages/transports/README.md
@@ -1,0 +1,49 @@
+# @fractal-mcp/transports
+
+Custom transport implementations for running Model Context Protocol (MCP) servers in
+browser-friendly environments.
+
+## MessagePort JSON-RPC transport
+
+`MessagePortRpcTransport` adapts the MCP JSON-RPC transport contract so that messages
+flow over a [`MessagePort`](https://developer.mozilla.org/docs/Web/API/MessagePort).
+This makes it possible to host MCP servers in SharedWorkers, WebWorkers, or iframes and
+communicate with them from browser-based clients without a network hop.
+
+### When to use it
+
+Use this transport whenever the client and server can exchange messages over a
+`MessageChannel`/`MessagePort` pair, for example when wiring [`mcp-anywhere`](https://github.com/modelcontextprotocol/mcp-anywhere)
+into a browser shell or moving server logic into a worker thread.
+It keeps the JSON-RPC surface identical to the official MCP transports while avoiding
+node-specific primitives like sockets or stdio.
+
+### Basic usage
+
+```ts
+import { MessageChannel } from "node:worker_threads";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+
+import { MessagePortRpcTransport } from "@fractal-mcp/transports";
+import { createHelloMcpServer } from "@fractal-mcp/test-utils-mcp";
+
+const channel = new MessageChannel();
+const server = createHelloMcpServer();
+const serverTransport = new MessagePortRpcTransport({ port: channel.port1 });
+await server.connect(serverTransport);
+
+const client = new Client({ name: "browser-client", version: "0.1.0" });
+const clientTransport = new MessagePortRpcTransport({ port: channel.port2 });
+await client.connect(clientTransport);
+
+const tools = await client.listTools();
+```
+
+### Design notes
+
+- The transport does not require `@modelcontextprotocol/sdk` at runtime. Only TypeScript
+  type information is imported, so the compiled JavaScript stays dependency-free.
+- `start()` automatically attaches message listeners and, by default, invokes
+  `port.start()` so that both WebWorker and MessageChannel ports behave consistently.
+- `send()` and `close()` guard against use-after-close scenarios and propagate errors
+  through the standard MCP transport callbacks.

--- a/packages/transports/jest.config.cjs
+++ b/packages/transports/jest.config.cjs
@@ -1,0 +1,19 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  preset: 'ts-jest/presets/default-esm',
+  testEnvironment: 'node',
+  roots: ['<rootDir>/tests'],
+  testMatch: ['**/*.test.ts'],
+  extensionsToTreatAsEsm: ['.ts'],
+  moduleNameMapper: {
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+    '^@fractal-mcp/test-utils-mcp$': '<rootDir>/../test-utils-mcp/src/index.ts'
+  },
+  transform: {
+    '^.+\\.ts$': ['ts-jest', {
+      useESM: true,
+      tsconfig: 'tsconfig.test.json'
+    }]
+  },
+  testTimeout: 30000
+};

--- a/packages/transports/package.json
+++ b/packages/transports/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@fractal-mcp/transports",
+  "version": "1.0.0",
+  "description": "Browser-friendly JSON-RPC transports for MCP",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/fractal-mcp/sdk.git"
+  },
+  "type": "module",
+  "types": "./dist/index.d.ts",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc",
+    "dev": "tsc --watch",
+    "clean": "rm -rf dist",
+    "lint": "eslint src",
+    "lint:fix": "eslint src --fix",
+    "test": "node --experimental-vm-modules --no-warnings ../../node_modules/jest/bin/jest.js"
+  },
+  "files": [
+    "dist",
+    "src",
+    "README.md"
+  ],
+  "devDependencies": {
+    "@fractal-mcp/test-utils-mcp": "^1.0.0",
+    "@modelcontextprotocol/sdk": "^1.0.0",
+    "@types/jest": "^29.5.14",
+    "@types/node": "^20.0.0",
+    "eslint": "^9.37.0",
+    "jest": "^29.7.0",
+    "ts-jest": "^29.4.0",
+    "typescript": "^5.0.0"
+  }
+}

--- a/packages/transports/src/index.ts
+++ b/packages/transports/src/index.ts
@@ -1,0 +1,5 @@
+export { MessagePortRpcTransport } from "./messagePortTransport.js";
+export type {
+  MessagePortLike,
+  MessagePortRpcTransportOptions
+} from "./messagePortTransport.js";

--- a/packages/transports/src/messagePortTransport.ts
+++ b/packages/transports/src/messagePortTransport.ts
@@ -1,0 +1,117 @@
+import type { JSONRPCMessage, MessageExtraInfo } from "@modelcontextprotocol/sdk/types.js";
+import type { Transport, TransportSendOptions } from "@modelcontextprotocol/sdk/shared/transport.js";
+
+type MessageEventType = "message" | "messageerror";
+
+type MessagePortEvent = {
+  data: unknown;
+};
+
+type MessagePortListener = (event: MessagePortEvent) => void;
+
+export interface MessagePortLike {
+  start?: () => void;
+  close: () => void;
+  postMessage: (message: unknown, transfer?: unknown[]) => void;
+  addEventListener: (type: MessageEventType, listener: MessagePortListener) => void;
+  removeEventListener: (type: MessageEventType, listener: MessagePortListener) => void;
+}
+
+export interface MessagePortRpcTransportOptions {
+  port: MessagePortLike;
+  /**
+   * Controls whether the transport should automatically call `start()` on the
+   * provided port during initialization. This mirrors the behavior of real
+   * MessagePorts in the browser, where `start()` begins message dispatch.
+   *
+   * Defaults to `true`.
+   */
+  autoStart?: boolean;
+}
+
+/**
+ * A Transport implementation that bridges JSON-RPC messages across a
+ * {@link MessagePort} pair. This is primarily intended for browser use where
+ * clients and servers may communicate across different execution contexts such
+ * as iframes, Web Workers, or other MessageChannel endpoints.
+ */
+export class MessagePortRpcTransport implements Transport {
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: (message: JSONRPCMessage, extra?: MessageExtraInfo) => void;
+  sessionId?: string;
+  setProtocolVersion?: (version: string) => void;
+
+  readonly #port: MessagePortLike;
+  readonly #autoStart: boolean;
+  #started = false;
+  #closed = false;
+
+  constructor(options: MessagePortRpcTransportOptions) {
+    this.#port = options.port;
+    this.#autoStart = options.autoStart ?? true;
+  }
+
+  async start(): Promise<void> {
+    if (this.#closed) {
+      throw new Error("Cannot start a transport that has been closed");
+    }
+    if (this.#started) {
+      return;
+    }
+    this.#started = true;
+    this.#port.addEventListener("message", this.#handleMessage);
+    this.#port.addEventListener("messageerror", this.#handleMessageError);
+    if (this.#autoStart && typeof this.#port.start === "function") {
+      this.#port.start();
+    }
+  }
+
+  async send(message: JSONRPCMessage, _options?: TransportSendOptions): Promise<void> {
+    if (this.#closed) {
+      throw new Error("Cannot send over a closed transport");
+    }
+    if (!this.#started) {
+      await this.start();
+    }
+    this.#port.postMessage(message);
+  }
+
+  async close(): Promise<void> {
+    if (this.#closed) {
+      return;
+    }
+    this.#closed = true;
+    if (this.#started) {
+      this.#port.removeEventListener("message", this.#handleMessage);
+      this.#port.removeEventListener("messageerror", this.#handleMessageError);
+    }
+    this.#port.close();
+    if (this.onclose) {
+      this.onclose();
+    }
+  }
+
+  readonly #handleMessage: MessagePortListener = (event) => {
+    if (this.#closed) {
+      return;
+    }
+    try {
+      this.onmessage?.(event.data as JSONRPCMessage);
+    } catch (error) {
+      this.onerror?.(error instanceof Error ? error : new Error(String(error)));
+    }
+  };
+
+  readonly #handleMessageError: MessagePortListener = (event) => {
+    if (this.#closed) {
+      return;
+    }
+    const detail = event?.data;
+    const error =
+      detail instanceof Error
+        ? detail
+        : new Error(typeof detail === "string" ? detail : "MessagePort transport encountered an error event");
+    this.onerror?.(error);
+  };
+}

--- a/packages/transports/tests/messagePortTransport.test.ts
+++ b/packages/transports/tests/messagePortTransport.test.ts
@@ -1,0 +1,111 @@
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+
+import {
+  createHelloMcpServer,
+  testHelloMcpServerBasicOperations
+} from "@fractal-mcp/test-utils-mcp";
+import { MessagePortRpcTransport } from "../src/messagePortTransport.js";
+
+type MessageHandler = (event: FakeMessageEvent) => void;
+
+type FakeMessageEvent = {
+  data: unknown;
+};
+
+type MessageEventType = "message" | "messageerror";
+
+class FakeMessagePort {
+  #listeners: Record<MessageEventType, Set<MessageHandler>> = {
+    message: new Set(),
+    messageerror: new Set()
+  };
+  #peer?: FakeMessagePort;
+  #closed = false;
+  onmessage: MessageHandler | null = null;
+  onmessageerror: MessageHandler | null = null;
+
+  setPeer(peer: FakeMessagePort): void {
+    this.#peer = peer;
+  }
+
+  start(): void {
+    // No-op for compatibility with real MessagePort behavior
+  }
+
+  close(): void {
+    this.#closed = true;
+  }
+
+  addEventListener(type: MessageEventType, listener: MessageHandler): void {
+    this.#listeners[type].add(listener);
+  }
+
+  removeEventListener(type: MessageEventType, listener: MessageHandler): void {
+    this.#listeners[type].delete(listener);
+  }
+
+  postMessage(data: unknown): void {
+    if (this.#closed) {
+      throw new Error("Cannot postMessage on a closed port");
+    }
+    if (!this.#peer) {
+      throw new Error("Cannot postMessage without a peer");
+    }
+    queueMicrotask(() => {
+      const peer = this.#peer;
+      if (peer) {
+        peer.#dispatch("message", { data });
+      }
+    });
+  }
+
+  #dispatch(type: MessageEventType, event: FakeMessageEvent): void {
+    if (this.#closed) {
+      return;
+    }
+    const listeners = this.#listeners[type];
+    for (const listener of listeners) {
+      listener(event);
+    }
+    if (type === "message" && this.onmessage) {
+      this.onmessage(event);
+    }
+    if (type === "messageerror" && this.onmessageerror) {
+      this.onmessageerror(event);
+    }
+  }
+}
+
+class FakeMessageChannel {
+  readonly port1: FakeMessagePort;
+  readonly port2: FakeMessagePort;
+
+  constructor() {
+    this.port1 = new FakeMessagePort();
+    this.port2 = new FakeMessagePort();
+    this.port1.setPeer(this.port2);
+    this.port2.setPeer(this.port1);
+  }
+}
+
+describe("MessagePortRpcTransport", () => {
+  it("supports basic hello server operations over a MessageChannel", async () => {
+    const channel = new FakeMessageChannel();
+    const server = createHelloMcpServer();
+    const serverTransport = new MessagePortRpcTransport({ port: channel.port1 });
+    await server.connect(serverTransport);
+
+    const clientTransport = new MessagePortRpcTransport({ port: channel.port2 });
+    const client = new Client({
+      name: "MessagePortTransportTestClient",
+      version: "0.1.0"
+    });
+    await client.connect(clientTransport);
+
+    try {
+      await testHelloMcpServerBasicOperations(client);
+    } finally {
+      await Promise.all([client.close(), server.close()]);
+    }
+  });
+});

--- a/packages/transports/tsconfig.json
+++ b/packages/transports/tsconfig.json
@@ -1,0 +1,18 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "node",
+    "declaration": true,
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "forceConsistentCasingInFileNames": true,
+    "resolveJsonModule": true,
+    "lib": ["ES2020"]
+  },
+  "include": ["src/**/*"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/transports/tsconfig.test.json
+++ b/packages/transports/tsconfig.test.json
@@ -1,0 +1,12 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["jest", "node"],
+    "noEmit": true,
+    "rootDir": "../..",
+    "paths": {
+      "@fractal-mcp/test-utils-mcp": ["../test-utils-mcp/src/index.ts"]
+    }
+  },
+  "include": ["tests/**/*.ts", "src/**/*.ts"]
+}


### PR DESCRIPTION
## Summary
- rename the MessagePort JSON-RPC transport class to MessagePortRpcTransport and align usage
- expose the basic hello server test helper alongside other testcases with README coverage

## Testing
- npm run test -- --filter=@fractal-mcp/transports

------
https://chatgpt.com/codex/tasks/task_e_68f4e92f6244832db87b0fc00ef3364f